### PR TITLE
添加播放列表上下文功能：支持从时光机回忆列表播放音乐

### DIFF
--- a/lib/pages/memory_page.dart
+++ b/lib/pages/memory_page.dart
@@ -129,7 +129,16 @@ class _MemoryPageState extends State<MemoryPage> {
     HapticFeedback.lightImpact();
     final spotifyProvider = Provider.of<SpotifyProvider>(context, listen: false);
     try {
-      spotifyProvider.playTrack(trackUri: memory.trackUri);
+      // 收集所有 track URIs
+      final trackUris = _memories.map((m) => m.trackUri).toList();
+      // 找到当前点击的 memory 在列表中的索引
+      final currentIndex = _memories.indexOf(memory);
+
+      // 使用整个列表作为上下文播放
+      spotifyProvider.playTracks(
+        trackUris: trackUris,
+        offsetIndex: currentIndex >= 0 ? currentIndex : 0,
+      );
     } catch (e) {
       _logger.w('Failed to play track: $e');
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/services/spotify_service.dart
+++ b/lib/services/spotify_service.dart
@@ -1294,6 +1294,42 @@ class SpotifyAuthService {
     }
   }
 
+  /// 播放多个曲目（使用 URIs 列表创建临时播放上下文）
+  Future<void> playTracks({
+    required List<String> trackUris,
+    int? offsetIndex,
+    String? deviceId,
+  }) async {
+    try {
+      final headers =
+          await _authHeaders(hasBody: true); // PUT request with body
+      final body = {
+        'uris': trackUris,
+      };
+
+      // 如果指定了偏移量，添加 offset 参数
+      if (offsetIndex != null) {
+        body['offset'] = {'position': offsetIndex};
+      }
+
+      final queryParams = deviceId != null ? '?device_id=$deviceId' : '';
+      final response = await http.put(
+        Uri.parse('https://api.spotify.com/v1/me/player/play$queryParams'),
+        headers: headers,
+        body: json.encode(body),
+      );
+
+      if (response.statusCode != 202 && response.statusCode != 204) {
+        throw SpotifyAuthException(
+          '开始播放失败: ${response.body}',
+          code: response.statusCode.toString(),
+        );
+      }
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   /// 在上下文中播放特定歌曲
   Future<void> playTrackInContext({
     required String contextUri,


### PR DESCRIPTION
- 在 SpotifyAuthService 中新增 playTracks 方法，支持播放多个曲目并创建临时播放上下文
- 在 SpotifyProvider 中添加 playTracks 包装方法，提供统一的设备检查和错误处理
- 修改 MemoryPage 播放逻辑，点击播放时将整个回忆列表作为上下文，而不是仅播放单曲
- 使用 offsetIndex 参数指定从点击的曲目开始播放

此改进允许用户在时光机页面播放音乐时，享受完整的播放列表体验，可以自动切换到下一首歌曲。