### PR TITLE
⚡ Bolt: Optimize `LyricsWidget` rebuilds by deriving active line index inside `Selector`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - [Optimize Flutter Provider Selector for High-Frequency Streams]
+**Learning:** When using `Selector` in Flutter with high-frequency streams (like audio playback `progressMs`), passing the raw rapidly changing value into the `builder` causes excessive widget rebuilds.
+**Action:** Calculate the stable derived state (e.g., `currentLineIndex`) *inside* the `selector` callback and return a snapshot containing only the derived state. Update `shouldRebuild` to compare this derived state, ensuring the UI only rebuilds when visually necessary (e.g., when the lyric line changes, not on every millisecond tick).

--- a/lib/widgets/lyrics.dart
+++ b/lib/widgets/lyrics.dart
@@ -38,11 +38,11 @@ class LyricLine {
 
 class _LyricsPlaybackSnapshot {
   final String? trackId;
-  final int progressMs;
+  final int currentLineIndex;
 
   const _LyricsPlaybackSnapshot({
     required this.trackId,
-    required this.progressMs,
+    required this.currentLineIndex,
   });
 }
 
@@ -1446,14 +1446,16 @@ class _LyricsWidgetState extends State<LyricsWidget>
         final progressMs = rawProgress is int
             ? rawProgress
             : int.tryParse(rawProgress?.toString() ?? '') ?? 0;
+        final latestPosition = Duration(milliseconds: progressMs);
+        final currentLineIndex = _getCurrentLineIndex(latestPosition);
         return _LyricsPlaybackSnapshot(
           trackId: trackId,
-          progressMs: progressMs,
+          currentLineIndex: currentLineIndex,
         );
       },
       shouldRebuild: (previous, next) =>
           previous.trackId != next.trackId ||
-          previous.progressMs != next.progressMs,
+          previous.currentLineIndex != next.currentLineIndex,
       builder: (context, playbackSnapshot, child) {
         // _logger.d('[LyricsBuilder] Build Start - PrevIdx: $_previousLineIndex'); // Log builder start
         final currentTrackId = playbackSnapshot.trackId;
@@ -1474,10 +1476,8 @@ class _LyricsWidgetState extends State<LyricsWidget>
         _syncLineKeys(_lyrics.length);
         _scheduleScrollabilityCheck();
 
-        // 2. Calculate latest position and index based on provider state
-        final latestPosition =
-            Duration(milliseconds: playbackSnapshot.progressMs);
-        final currentLineIndex = _getCurrentLineIndex(latestPosition);
+        // 2. Extract index based on snapshot state
+        final currentLineIndex = playbackSnapshot.currentLineIndex;
         final spotifyProvider =
             Provider.of<SpotifyProvider>(context, listen: false);
         // _logger.d('[LyricsBuilder] Calculated Idx: $currentLineIndex (from ${currentProgressMs}ms)'); // Log calculated index


### PR DESCRIPTION
⚡ Bolt: Optimize `LyricsWidget` Rebuilds

💡 **What:**
Optimized the `Selector` in `LyricsWidget` to calculate the active `currentLineIndex` inside the `selector` callback instead of passing the rapidly updating `progressMs` out to the `builder`.

🎯 **Why:**
Previously, the `_LyricsPlaybackSnapshot` was exposing `progressMs`. Since audio playback progress (`progressMs`) ticks extremely frequently (multiple times a second), the `shouldRebuild` condition (`previous.progressMs != next.progressMs`) was almost always evaluating to `true`. This caused the entire `LyricsWidget` to undergo heavy and continuous rebuilds, even when the currently highlighted lyric line had not changed.

By extracting the `currentLineIndex` inside the `selector` and updating the snapshot to hold this derived value, the widget now only triggers a rebuild when the user actually transitions to a new lyric line (or the track changes).

📊 **Impact:**
Massively reduces unnecessary widget subtree rebuilds. Re-renders in the `LyricsWidget` drop from continuous/frequent ticking (~every few ms during playback) down to roughly once every 3-5 seconds (whenever the lyric line advances). This leads to noticeably lower CPU usage and smoother scrolling/animations while lyrics are active.

🔬 **Measurement:**
This can be verified by observing CPU load during active playback in the Flutter DevTools Performance view, or by placing a `print` statement inside the `builder` of `LyricsWidget` and watching the drastically reduced output frequency.

---
*PR created automatically by Jules for task [3129309621830322619](https://jules.google.com/task/3129309621830322619) started by @p2o51*