### PR TITLE
⚡ Bolt: [Performance Improvement] Parallelize cache clearing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-02 - [Parallelize SharedPreferences removals]
+**Learning:** Sequential `await prefs.remove(key)` operations in loops for SharedPreferences keys can introduce unnecessary latency due to sequential disk I/O, especially when clearing large caches.
+**Action:** Use `Future.wait(futures)` to parallelize multiple independent asynchronous removal operations to optimize performance.

--- a/lib/services/lyrics_service.dart
+++ b/lib/services/lyrics_service.dart
@@ -194,12 +194,11 @@ class LyricsService {
       final prefs = await _getPrefs();
       final keys = prefs.getKeys();
 
-      // 只清除歌词缓存的键
-      for (var key in keys) {
-        if (key.startsWith(_cacheKeyPrefix)) {
-          await prefs.remove(key);
-        }
-      }
+      // 只清除歌词缓存的键，使用 Future.wait 并行删除以提升性能
+      final futures = keys
+          .where((key) => key.startsWith(_cacheKeyPrefix))
+          .map((key) => prefs.remove(key));
+      await Future.wait(futures);
       _logger.i('歌词缓存已清除');
     } catch (e) {
       _logger.e('清除缓存失败: $e');

--- a/lib/services/song_info_service.dart
+++ b/lib/services/song_info_service.dart
@@ -162,9 +162,8 @@ class SongInfoService {
       final keys = prefs.getKeys();
       final songInfoKeys = keys.where((key) => key.startsWith(_songInfoCacheKeyPrefix));
       
-      for (final key in songInfoKeys) {
-        await prefs.remove(key);
-      }
+      final futures = songInfoKeys.map((key) => prefs.remove(key));
+      await Future.wait(futures);
       logger.d('Cached song info cleared');
     } catch (e) {
       logger.e('Error clearing cached song info: $e');

--- a/lib/services/translation_service.dart
+++ b/lib/services/translation_service.dart
@@ -255,11 +255,10 @@ $lyricsText
       final prefs = await SharedPreferences.getInstance();
       final keys = prefs.getKeys();
 
-      for (var key in keys) {
-        if (key.startsWith(_cacheKeyPrefix)) {
-          await prefs.remove(key);
-        }
-      }
+      final futures = keys
+          .where((key) => key.startsWith(_cacheKeyPrefix))
+          .map((key) => prefs.remove(key));
+      await Future.wait(futures);
     } catch (e) {
       logger.d('Failed to clear translation cache: $e');
     }

--- a/test/lyrics_service_test.dart
+++ b/test/lyrics_service_test.dart
@@ -37,15 +37,15 @@ void main() {
               },
             },
           };
-          return http.Response(jsonEncode(response), 200,
-              headers: {'content-type': 'application/json'});
+          return http.Response.bytes(utf8.encode(jsonEncode(response)), 200,
+              headers: {'content-type': 'application/json; charset=utf-8'});
         }
 
         if (path.contains('fcg_query_lyric_new')) {
           final response = {'lyric': '[00:00]你瞒我瞒'};
           final bodyBytes = utf8.encode(jsonEncode(response));
           return http.Response.bytes(bodyBytes, 200,
-              headers: {'content-type': 'application/json'});
+              headers: {'content-type': 'application/json; charset=utf-8'});
         }
 
         return http.Response('Not Found', 404);


### PR DESCRIPTION
💡 **What**: Replaced sequential `await prefs.remove(key)` calls within loops with `Future.wait(futures)` across cache clearing methods in `LyricsService`, `TranslationService`, and `SongInfoService`. Also fixed a text encoding bug in tests.

🎯 **Why**: When clearing caches from SharedPreferences, doing sequential `await`s introduces unnecessary latency due to sequential disk I/O. Parallelizing these asynchronous operations reduces the total time spent clearing the cache.

📊 **Impact**: Expected to significantly reduce the execution time of `clearCache`, `clearTranslationCache`, and `clearCachedSongInfo` methods, especially when the caches contain a large number of entries.

🔬 **Measurement**: Verification was performed by running `flutter analyze` and `flutter test`. To measure performance impact in a real environment, you could profile the execution time of cache clearing functions before and after the change on a device with a large cached dataset.

---
*PR created automatically by Jules for task [343750069366518130](https://jules.google.com/task/343750069366518130) started by @p2o51*