### PR TITLE
⚡ Bolt: parallelize SharedPreferences cache removals

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Parallelize SharedPreferences Batch Removals]
+**Learning:** Sequential `await` calls in a loop for removing multiple keys from `SharedPreferences` can be slow. `SharedPreferences.remove` returns a `Future<bool>`, which allows us to collect these futures and run them concurrently using `Future.wait`.
+**Action:** When performing batch operations on `SharedPreferences` (like clearing a cache by key prefix), collect the `Future`s returned by `remove` (or `set`) into a list and await them all at once using `Future.wait(futures)` to optimize performance.

--- a/lib/services/lyrics_service.dart
+++ b/lib/services/lyrics_service.dart
@@ -195,11 +195,17 @@ class LyricsService {
       final keys = prefs.getKeys();
 
       // 只清除歌词缓存的键
+      // ⚡ Bolt: 使用 Future.wait 并行处理清除操作以提高性能
+      final futures = <Future<bool>>[];
       for (var key in keys) {
         if (key.startsWith(_cacheKeyPrefix)) {
-          await prefs.remove(key);
+          futures.add(prefs.remove(key));
         }
       }
+      if (futures.isNotEmpty) {
+        await Future.wait(futures);
+      }
+
       _logger.i('歌词缓存已清除');
     } catch (e) {
       _logger.e('清除缓存失败: $e');

--- a/test/lyrics_service_test.dart
+++ b/test/lyrics_service_test.dart
@@ -37,8 +37,8 @@ void main() {
               },
             },
           };
-          return http.Response(jsonEncode(response), 200,
-              headers: {'content-type': 'application/json'});
+          return http.Response.bytes(utf8.encode(jsonEncode(response)), 200,
+              headers: {'content-type': 'application/json; charset=utf-8'});
         }
 
         if (path.contains('fcg_query_lyric_new')) {


### PR DESCRIPTION
💡 **What:** 
Parallelized the removal of items from SharedPreferences in `LyricsService.clearCache` using `Future.wait`. Also fixed a failing unit test in `lyrics_service_test.dart` related to mock HTTP responses by providing proper UTF-8 charset headers and byte-encoding. Added a journal entry to `.jules/bolt.md` reflecting on this optimization.

🎯 **Why:** 
Sequential `await` calls in a loop for asynchronous operations (especially disk/preference writes) introduce unnecessary latency. By kicking off all the removals at once and then waiting for all of them to complete, we reduce the total time spent waiting on I/O.

📊 **Impact:** 
Reduces the time taken to clear the lyrics cache. The larger the cache, the more significant the time savings (from O(N * write_latency) to roughly O(1 * write_latency)).

🔬 **Measurement:** 
Run `flutter test` to verify no regressions in cache behavior and check that test suite passes. Check `.jules/bolt.md` for learning journal update.

---
*PR created automatically by Jules for task [11636367323437917376](https://jules.google.com/task/11636367323437917376) started by @p2o51*