### PR TITLE
⚡ Bolt: Batch SharedPreferences removals for faster cache clearing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - SharedPreferences Batch Removals
+**Learning:** Sequential `await prefs.remove(key)` calls within loops can significantly slow down clearing caches, especially when the cache contains many items.
+**Action:** Always prefer `Future.wait` to parallelize multiple independent asynchronous operations (e.g., `await Future.wait(keysToRemove.map((key) => prefs.remove(key)))`) to optimize performance over sequential `await` calls.

--- a/lib/services/lyrics_service.dart
+++ b/lib/services/lyrics_service.dart
@@ -194,12 +194,9 @@ class LyricsService {
       final prefs = await _getPrefs();
       final keys = prefs.getKeys();
 
-      // 只清除歌词缓存的键
-      for (var key in keys) {
-        if (key.startsWith(_cacheKeyPrefix)) {
-          await prefs.remove(key);
-        }
-      }
+      // 只清除歌词缓存的键，使用 Future.wait 并行删除以提高性能
+      final keysToRemove = keys.where((key) => key.startsWith(_cacheKeyPrefix));
+      await Future.wait(keysToRemove.map((key) => prefs.remove(key)));
       _logger.i('歌词缓存已清除');
     } catch (e) {
       _logger.e('清除缓存失败: $e');

--- a/lib/services/song_info_service.dart
+++ b/lib/services/song_info_service.dart
@@ -162,9 +162,8 @@ class SongInfoService {
       final keys = prefs.getKeys();
       final songInfoKeys = keys.where((key) => key.startsWith(_songInfoCacheKeyPrefix));
       
-      for (final key in songInfoKeys) {
-        await prefs.remove(key);
-      }
+      // Use Future.wait to parallelize removal and improve performance
+      await Future.wait(songInfoKeys.map((key) => prefs.remove(key)));
       logger.d('Cached song info cleared');
     } catch (e) {
       logger.e('Error clearing cached song info: $e');

--- a/lib/services/translation_service.dart
+++ b/lib/services/translation_service.dart
@@ -255,11 +255,9 @@ $lyricsText
       final prefs = await SharedPreferences.getInstance();
       final keys = prefs.getKeys();
 
-      for (var key in keys) {
-        if (key.startsWith(_cacheKeyPrefix)) {
-          await prefs.remove(key);
-        }
-      }
+      // Use Future.wait to parallelize removal and improve performance
+      final keysToRemove = keys.where((key) => key.startsWith(_cacheKeyPrefix));
+      await Future.wait(keysToRemove.map((key) => prefs.remove(key)));
     } catch (e) {
       logger.d('Failed to clear translation cache: $e');
     }

--- a/test/lyrics_service_test.dart
+++ b/test/lyrics_service_test.dart
@@ -37,7 +37,7 @@ void main() {
               },
             },
           };
-          return http.Response(jsonEncode(response), 200,
+          return http.Response.bytes(utf8.encode(jsonEncode(response)), 200,
               headers: {'content-type': 'application/json'});
         }
 


### PR DESCRIPTION
💡 **What**: Replaced sequential `await prefs.remove(key)` in `for` loops with `await Future.wait(keysToRemove.map((key) => prefs.remove(key)))` across multiple services (`lyrics_service`, `song_info_service`, `translation_service`).

🎯 **Why**: When clearing caches containing many items (like stored lyrics, song metadata, and translations), awaiting each `SharedPreferences.remove` operation sequentially forces the application to wait for an entire event loop cycle and disk I/O response for *each individual key*. This creates a noticeable UI block or stutter during operations like "Clear Cache."

📊 **Impact**: Reduces the time spent awaiting disk operations by running them concurrently. Expected to significantly speed up the cache clearing process, especially on older devices or when the cache has grown large.

🔬 **Measurement**: Verified by ensuring all tests pass (`flutter test`). Also fixed a character encoding issue in `lyrics_service_test.dart` to make sure the CI pipeline won't fail due to `http.Response` mocking.

---
*PR created automatically by Jules for task [16439722227768723656](https://jules.google.com/task/16439722227768723656) started by @p2o51*