### PR TITLE
⚡ Bolt: Optimize LyricsWidget rebuild frequency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - LyricsWidget Unnecessary Rebuilds
+**Learning:** `LyricsWidget` was using a `Selector` that returned raw `progressMs` (which updates multiple times a second). This caused the entire widget (including large list views and translation overlays) to rebuild unnecessarily on every progress tick.
+**Action:** When depending on high-frequency streams like audio playback progress, calculate the stable derived state (e.g., `currentLineIndex`) within the `selector` callback and return a value-equatable snapshot. This prevents unnecessary rebuilds.

--- a/lib/widgets/lyrics.dart
+++ b/lib/widgets/lyrics.dart
@@ -36,14 +36,25 @@ class LyricLine {
   LyricLine(this.timestamp, this.text, {this.translation});
 }
 
-class _LyricsPlaybackSnapshot {
+class _LyricsDerivedSnapshot {
   final String? trackId;
-  final int progressMs;
+  final int currentLineIndex;
 
-  const _LyricsPlaybackSnapshot({
+  const _LyricsDerivedSnapshot({
     required this.trackId,
-    required this.progressMs,
+    required this.currentLineIndex,
   });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is _LyricsDerivedSnapshot &&
+        other.trackId == trackId &&
+        other.currentLineIndex == currentLineIndex;
+  }
+
+  @override
+  int get hashCode => trackId.hashCode ^ currentLineIndex.hashCode;
 }
 
 class LyricsWidget extends StatefulWidget {
@@ -1438,7 +1449,7 @@ class _LyricsWidgetState extends State<LyricsWidget>
     final l10n = AppLocalizations.of(context)!;
 
     // Use Selector to react only to playback changes that affect lyrics
-    return Selector<SpotifyProvider, _LyricsPlaybackSnapshot>(
+    return Selector<SpotifyProvider, _LyricsDerivedSnapshot>(
       selector: (context, provider) {
         final currentTrack = provider.currentTrack;
         final trackId = currentTrack?['item']?['id']?.toString();
@@ -1446,17 +1457,23 @@ class _LyricsWidgetState extends State<LyricsWidget>
         final progressMs = rawProgress is int
             ? rawProgress
             : int.tryParse(rawProgress?.toString() ?? '') ?? 0;
-        return _LyricsPlaybackSnapshot(
+
+        final latestPosition = Duration(milliseconds: progressMs);
+        // Calculate the current index directly in the selector
+        final derivedIndex = _getCurrentLineIndex(latestPosition);
+
+        return _LyricsDerivedSnapshot(
           trackId: trackId,
-          progressMs: progressMs,
+          currentLineIndex: derivedIndex,
         );
       },
       shouldRebuild: (previous, next) =>
           previous.trackId != next.trackId ||
-          previous.progressMs != next.progressMs,
+          previous.currentLineIndex != next.currentLineIndex,
       builder: (context, playbackSnapshot, child) {
         // _logger.d('[LyricsBuilder] Build Start - PrevIdx: $_previousLineIndex'); // Log builder start
         final currentTrackId = playbackSnapshot.trackId;
+        final currentLineIndex = playbackSnapshot.currentLineIndex;
         final bool trackJustChanged = (currentTrackId != _lastTrackId);
 
         // 1. Handle track change: Load lyrics if track ID changes
@@ -1474,13 +1491,10 @@ class _LyricsWidgetState extends State<LyricsWidget>
         _syncLineKeys(_lyrics.length);
         _scheduleScrollabilityCheck();
 
-        // 2. Calculate latest position and index based on provider state
-        final latestPosition =
-            Duration(milliseconds: playbackSnapshot.progressMs);
-        final currentLineIndex = _getCurrentLineIndex(latestPosition);
+        // 2. Index is now derived directly from the selector
         final spotifyProvider =
             Provider.of<SpotifyProvider>(context, listen: false);
-        // _logger.d('[LyricsBuilder] Calculated Idx: $currentLineIndex (from ${currentProgressMs}ms)'); // Log calculated index
+        // _logger.d('[LyricsBuilder] Calculated Idx: $currentLineIndex'); // Log calculated index
 
         if (_autoScroll &&
             _lyrics.isNotEmpty &&

--- a/test/lyrics_service_test.dart
+++ b/test/lyrics_service_test.dart
@@ -37,15 +37,15 @@ void main() {
               },
             },
           };
-          return http.Response(jsonEncode(response), 200,
-              headers: {'content-type': 'application/json'});
+          return http.Response.bytes(utf8.encode(jsonEncode(response)), 200,
+              headers: {'content-type': 'application/json; charset=utf-8'});
         }
 
         if (path.contains('fcg_query_lyric_new')) {
           final response = {'lyric': '[00:00]你瞒我瞒'};
           final bodyBytes = utf8.encode(jsonEncode(response));
           return http.Response.bytes(bodyBytes, 200,
-              headers: {'content-type': 'application/json'});
+              headers: {'content-type': 'application/json; charset=utf-8'});
         }
 
         return http.Response('Not Found', 404);


### PR DESCRIPTION
💡 **What:** 
Optimized the `Selector` in `LyricsWidget` (`lib/widgets/lyrics.dart`). It now uses a new `_LyricsDerivedSnapshot` class which calculates and stores the `currentLineIndex` directly in the `selector` function, rather than passing raw `progressMs` down to the widget builder. Also fixed a pre-existing test failure in `test/lyrics_service_test.dart` related to JSON encoding.

🎯 **Why:** 
The Spotify playback state updates `progressMs` extremely frequently (multiple times a second). Previously, the `LyricsWidget` was rebuilding its entire heavy UI tree (including long `ListView`s, gradient overlays, and complex translation logic) on every single tick, leading to high CPU usage and potential frame drops.

📊 **Impact:** 
Massively reduces unnecessary widget rebuilds. The `LyricsWidget` will now only rebuild when the actual active lyric line changes (or the track changes), instead of multiple times per second during playback. This saves CPU cycles and improves scrolling/animation smoothness.

🔬 **Measurement:** 
- Tested via `flutter analyze` and `flutter test`. 
- Verified logic ensures `shouldRebuild` only evaluates to `true` when the derived `currentLineIndex` or `trackId` changes.
- Can be confirmed visually by using Flutter DevTools (Performance view) and observing the drastically reduced widget rebuild count for `LyricsWidget` during normal playback.

---
*PR created automatically by Jules for task [47720224643877693](https://jules.google.com/task/47720224643877693) started by @p2o51*