### PR TITLE
⚡ Bolt: Optimize independent Spotify API calls with Future.wait

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Avoid Sequential Awaits in Spotify API Refresh]
+**Learning:** Sequential `await` calls for independent asynchronous operations (like refreshing tracks, devices, and queue from Spotify API) create unnecessary bottlenecks and accumulate latency. The `SpotifyPlaybackManager` was suffering from this pattern.
+**Action:** Use `Future.wait` to parallelize multiple independent asynchronous operations, specifically in the initialization and refresh cycles of API orchestrators, to minimize total execution time.

--- a/lib/managers/spotify_playback_manager.dart
+++ b/lib/managers/spotify_playback_manager.dart
@@ -91,9 +91,11 @@ class SpotifyPlaybackManager {
     Future.microtask(() async {
       try {
         logger.d('startTrackRefresh (microtask): 获取初始数据...');
-        await onRefreshTrack();
-        await onRefreshDevices();
-        await onRefreshQueue();
+        await Future.wait([
+          onRefreshTrack(),
+          onRefreshDevices(),
+          onRefreshQueue(),
+        ]);
         markQueueRefreshed();
         markDevicesRefreshed();
         logger.i('startTrackRefresh (microtask): 初始数据获取完成');
@@ -125,15 +127,26 @@ class SpotifyPlaybackManager {
           Future(() async {
             try {
               logger.t('_refreshTimer tick: 刷新曲目、设备和队列');
-              await onRefreshTrack();
+              final refreshTasks = <Future<void>>[
+                onRefreshTrack(),
+              ];
 
-              if (shouldRefreshDevices()) {
-                await onRefreshDevices();
-                markDevicesRefreshed();
+              final refreshDevices = shouldRefreshDevices();
+              if (refreshDevices) {
+                refreshTasks.add(onRefreshDevices());
               }
 
-              if (shouldRefreshQueue()) {
-                await onRefreshQueue();
+              final refreshQueue = shouldRefreshQueue();
+              if (refreshQueue) {
+                refreshTasks.add(onRefreshQueue());
+              }
+
+              await Future.wait(refreshTasks);
+
+              if (refreshDevices) {
+                markDevicesRefreshed();
+              }
+              if (refreshQueue) {
                 markQueueRefreshed();
               }
             } finally {
@@ -575,16 +588,22 @@ class SpotifyPlaybackManager {
     try {
       switch (mode) {
         case PlayMode.singleRepeat:
-          await guard(() => getService().setRepeatMode('track'));
-          await guard(() => getService().setShuffle(false));
+          await Future.wait([
+            guard(() => getService().setRepeatMode('track')),
+            guard(() => getService().setShuffle(false)),
+          ]);
           break;
         case PlayMode.sequential:
-          await guard(() => getService().setRepeatMode('context'));
-          await guard(() => getService().setShuffle(false));
+          await Future.wait([
+            guard(() => getService().setRepeatMode('context')),
+            guard(() => getService().setShuffle(false)),
+          ]);
           break;
         case PlayMode.shuffle:
-          await guard(() => getService().setRepeatMode('context'));
-          await guard(() => getService().setShuffle(true));
+          await Future.wait([
+            guard(() => getService().setRepeatMode('context')),
+            guard(() => getService().setShuffle(true)),
+          ]);
           break;
       }
       _currentMode = mode;


### PR DESCRIPTION
💡 What: Refactored `SpotifyPlaybackManager` to execute independent asynchronous API calls concurrently using `Future.wait`. This applies to the initial track/device/queue fetch, periodic refreshes, and playback mode updates (repeat + shuffle).
🎯 Why: Sequential `await` calls for independent operations accumulate latency, creating unnecessary bottlenecks. Fetching tracks, devices, and queue sequentially took `t1 + t2 + t3` time, while concurrently it takes `max(t1, t2, t3)`.
📊 Impact: Significantly reduces the total wall-clock time required for Spotify state synchronization. E.g., if track, device, and queue fetches each take 150ms, the refresh cycle drops from ~450ms to ~150ms, yielding a ~66% latency reduction during these critical updates.
🔬 Measurement: Can be verified by profiling network request timelines during app startup and periodic playback state refreshes. Network traces should show requests dispatched simultaneously rather than sequentially.

---
*PR created automatically by Jules for task [11978671288517631888](https://jules.google.com/task/11978671288517631888) started by @p2o51*