### PR TITLE
⚡ Bolt: Use binary search for current lyric line index

### DIFF
--- a/lib/utils/lyrics_parser.dart
+++ b/lib/utils/lyrics_parser.dart
@@ -109,10 +109,21 @@ class LyricsParser {
       return -1;
     }
 
-    // 从后向前查找最后一个时间戳小于等于当前位置的行
-    for (int i = lyrics.length - 1; i >= 0; i--) {
-      if (lyrics[i].timestamp <= currentPosition) {
-        return i;
+    // 二分查找最后一个时间戳小于等于当前位置的行
+    int low = 0;
+    int high = lyrics.length - 1;
+    while (low <= high) {
+      final mid = (low + high) >> 1;
+      final midTimestamp = lyrics[mid].timestamp;
+      if (midTimestamp <= currentPosition) {
+        final isLastMatch = mid == lyrics.length - 1 ||
+            lyrics[mid + 1].timestamp > currentPosition;
+        if (isLastMatch) {
+          return mid;
+        }
+        low = mid + 1;
+      } else {
+        high = mid - 1;
       }
     }
 

--- a/lib/widgets/lyrics_selection_page.dart
+++ b/lib/widgets/lyrics_selection_page.dart
@@ -363,10 +363,21 @@ class _LyricsSelectionPageState extends State<LyricsSelectionPage> {
       return -1;
     }
 
-    // 找到最后一行其时间戳小于等于当前位置的行
-    for (int i = _lyricLines.length - 1; i >= 0; i--) {
-      if (_lyricLines[i].timestamp <= currentPosition) {
-        return i;
+    // 二分查找最后一行其时间戳小于等于当前位置的行
+    int low = 0;
+    int high = _lyricLines.length - 1;
+    while (low <= high) {
+      final mid = (low + high) >> 1;
+      final midTimestamp = _lyricLines[mid].timestamp;
+      if (midTimestamp <= currentPosition) {
+        final isLastMatch = mid == _lyricLines.length - 1 ||
+            _lyricLines[mid + 1].timestamp > currentPosition;
+        if (isLastMatch) {
+          return mid;
+        }
+        low = mid + 1;
+      } else {
+        high = mid - 1;
       }
     }
 

--- a/test/utils/lyrics_parser_test.dart
+++ b/test/utils/lyrics_parser_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spotoolfy_flutter/utils/lyrics_parser.dart';
+import 'package:spotoolfy_flutter/models/lyric_line.dart';
+
+void main() {
+  group('LyricsParser.getCurrentLineIndex', () {
+    test('returns -1 for empty lyrics list', () {
+      expect(LyricsParser.getCurrentLineIndex([], Duration.zero), -1);
+    });
+
+    test('returns -1 if current position is before the first lyric line', () {
+      final lyrics = [
+        LyricLine(const Duration(seconds: 10), 'First line'),
+        LyricLine(const Duration(seconds: 20), 'Second line'),
+      ];
+      expect(LyricsParser.getCurrentLineIndex(lyrics, const Duration(seconds: 5)), -1);
+    });
+
+    test('returns correct index when position is exactly on a lyric line', () {
+      final lyrics = [
+        LyricLine(const Duration(seconds: 10), 'First line'),
+        LyricLine(const Duration(seconds: 20), 'Second line'),
+        LyricLine(const Duration(seconds: 30), 'Third line'),
+      ];
+      expect(LyricsParser.getCurrentLineIndex(lyrics, const Duration(seconds: 20)), 1);
+    });
+
+    test('returns correct index when position is between two lyric lines', () {
+      final lyrics = [
+        LyricLine(const Duration(seconds: 10), 'First line'),
+        LyricLine(const Duration(seconds: 20), 'Second line'),
+        LyricLine(const Duration(seconds: 30), 'Third line'),
+      ];
+      expect(LyricsParser.getCurrentLineIndex(lyrics, const Duration(seconds: 25)), 1);
+    });
+
+    test('returns last index when position is after the last lyric line', () {
+      final lyrics = [
+        LyricLine(const Duration(seconds: 10), 'First line'),
+        LyricLine(const Duration(seconds: 20), 'Second line'),
+      ];
+      expect(LyricsParser.getCurrentLineIndex(lyrics, const Duration(seconds: 30)), 1);
+    });
+
+    test('handles consecutive lines with identical timestamps', () {
+      final lyrics = [
+        LyricLine(const Duration(seconds: 10), 'First line'),
+        LyricLine(const Duration(seconds: 10), 'Same time line'),
+        LyricLine(const Duration(seconds: 20), 'Second line'),
+      ];
+      // According to the binary search logic, if there are multiple identical timestamps,
+      // and we search for exactly that timestamp, it should return the last matching index
+      // where the next timestamp is > currentPosition, OR it's the end of the array.
+      // In this specific implementation, it returns 1.
+      expect(LyricsParser.getCurrentLineIndex(lyrics, const Duration(seconds: 10)), 1);
+      expect(LyricsParser.getCurrentLineIndex(lyrics, const Duration(seconds: 15)), 1);
+    });
+  });
+}


### PR DESCRIPTION
💡 **What:** 
Replaced the backwards linear scan `O(N)` algorithm with a binary search `O(log N)` algorithm for determining the active lyric line index based on current playback time. This change was applied to `lib/utils/lyrics_parser.dart` and `lib/widgets/lyrics_selection_page.dart`. A new unit test file (`test/utils/lyrics_parser_test.dart`) was also added to guarantee correctness.

🎯 **Why:** 
The previous approach searched backwards from the end of the lyrics array to find the current line. While functionally correct, it had an `O(N)` complexity where `N` is the total number of lines in a song. Because lyric tracking widgets re-evaluate the current line multiple times per second (e.g., using a high-frequency `progress_ms` stream from Spotify), this caused unnecessary CPU overhead.

📊 **Impact:** 
Algorithmic complexity is reduced from `O(N)` to `O(log N)`. For a song with 100 lyric lines, finding the current line now takes at most 7 comparisons instead of potentially 100, minimizing work done on the UI thread during high-frequency tick events.

🔬 **Measurement:** 
Unit tests were added and passed `flutter test`. The change is non-breaking and transparently behaves identically to the old linear approach, gracefully falling through edge cases (no lyrics, before first lyric, exact matches, multiple identical timestamps).

*Note: No `pubspec` files were modified.*

---
*PR created automatically by Jules for task [15789528039603082817](https://jules.google.com/task/15789528039603082817) started by @p2o51*