### PR TITLE
⚡ Bolt: [performance improvement] Batch image preloads with Future.wait

### DIFF
--- a/lib/managers/spotify_cache_manager.dart
+++ b/lib/managers/spotify_cache_manager.dart
@@ -57,9 +57,8 @@ class SpotifyCacheManager {
     final uncachedUrls =
         imageUrls.where((url) => !isImageCached(url)).toList();
 
-    for (final url in uncachedUrls) {
-      await preloadImage(url, context);
-    }
+    // ⚡ Bolt: 性能优化 - 并发预加载队列图片，减少缓存过程的整体耗时，避免阻塞主线程
+    await Future.wait(uncachedUrls.map((url) => preloadImage(url, context)));
   }
 
   /// 清除图片缓存


### PR DESCRIPTION
💡 What: Replaced a sequential `for` loop `await` with `await Future.wait` when preloading a list of uncached images in `SpotifyCacheManager`.
🎯 Why: Using a sequential `await` inside a `for` loop causes independent asynchronous network requests (image fetching) to occur one after another, creating a waterfall effect that unnecessarily delays the completion of the method.
📊 Impact: Considerably speeds up the preloading process, especially when a queue has multiple missing images. Load times go from `time(img1) + time(img2) + ...` to approximately `max(time(img1), time(img2), ...)`.
🔬 Measurement: Can be verified by measuring the execution time of `preloadImageQueue` with multiple uncached images; the overall duration will be noticeably shorter.

---
*PR created automatically by Jules for task [9927491421501042930](https://jules.google.com/task/9927491421501042930) started by @p2o51*