### PR TITLE
⚡ Bolt: Batch image preloading

### DIFF
--- a/lib/managers/spotify_cache_manager.dart
+++ b/lib/managers/spotify_cache_manager.dart
@@ -57,9 +57,8 @@ class SpotifyCacheManager {
     final uncachedUrls =
         imageUrls.where((url) => !isImageCached(url)).toList();
 
-    for (final url in uncachedUrls) {
-      await preloadImage(url, context);
-    }
+    // ⚡ Bolt: 性能优化 - 并发预加载图片，显著减少整体加载时间
+    await Future.wait(uncachedUrls.map((url) => preloadImage(url, context)));
   }
 
   /// 清除图片缓存


### PR DESCRIPTION
💡 What: Replaced a sequential `await` `for` loop in `SpotifyCacheManager.preloadImages` with a batched `Future.wait` execution for fetching multiple uncached images concurrently.
🎯 Why: To prevent waterfall execution of network requests when preloading multiple images, dramatically improving load times.
📊 Impact: Reduces overall wait time for multiple image loads by executing requests concurrently rather than sequentially.
🔬 Measurement: Review network waterfalls in DevTools or measure total duration of `preloadImages` calls with multiple URLs.

---
*PR created automatically by Jules for task [14765282101604058900](https://jules.google.com/task/14765282101604058900) started by @p2o51*