### PR TITLE
⚡ Bolt: Replace sequential Spotify API pagination with concurrent chunked fetches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-05-19 - [Optimize Flutter Provider Selector for High-Frequency Streams]
 **Learning:** When using `Selector` in Flutter with high-frequency streams (like audio playback `progressMs`), passing the raw rapidly changing value into the `builder` causes excessive widget rebuilds.
 **Action:** Calculate the stable derived state (e.g., `currentLineIndex`) *inside* the `selector` callback and return a snapshot containing only the derived state. Update `shouldRebuild` to compare this derived state, ensuring the UI only rebuilds when visually necessary (e.g., when the lyric line changes, not on every millisecond tick).
+
+## 2024-05-19 - [Avoid 'Hot' Futures During API Rate Limit Chunking]
+**Learning:** In Dart, `Future`s are "hot"—execution begins immediately when the async function is called. When refactoring loops to chunk concurrent requests (e.g., batching Spotify API pagination to respect rate limits), pre-populating a list with all futures and then `await Future.wait(chunk)` actually fires ALL requests immediately at creation, defeating the rate limit and potentially causing network exhaustion.
+**Action:** To properly chunk concurrent requests, you must instantiate the `Future` (call the async method) *inside* the batch execution loop for that specific chunk, rather than generating them all upfront.

--- a/lib/providers/spotify_provider.dart
+++ b/lib/providers/spotify_provider.dart
@@ -1552,23 +1552,31 @@ class SpotifyProvider extends ChangeNotifier {
     ];
 
     final total = (tracksSection['total'] as int?) ?? allTracks.length;
-    var offset = allTracks.length;
+    final initialOffset = allTracks.length;
+    const limit = 50; // Spotify album tracks limit is 50
 
-    while (offset < total) {
-      final page = await _guard(
-          () => _spotifyService.getAlbumTracks(albumId, offset: offset));
-      final pageItems = page['items'] as List? ?? const [];
-      final extracted = <Map<String, dynamic>>[
-        for (final item in pageItems)
-          if (item is Map<String, dynamic>) Map<String, dynamic>.from(item)
-      ];
-      if (extracted.isEmpty) {
-        break;
-      }
-      allTracks.addAll(extracted);
-      offset = allTracks.length;
-      if (page['next'] == null) {
-        break;
+    if (initialOffset < total) {
+      // ⚡ Bolt: Use Future.wait to fetch independent pages concurrently in chunks of 5.
+      // This prevents the waterfall effect and reduces load time without hitting rate limits.
+      const chunkSize = 5;
+      for (int currentOffset = initialOffset; currentOffset < total; currentOffset += limit * chunkSize) {
+        final chunkFutures = <Future<Map<String, dynamic>>>[];
+        for (int i = 0; i < chunkSize; i++) {
+          final pageOffset = currentOffset + (i * limit);
+          if (pageOffset >= total) break;
+          chunkFutures.add(_guard(
+              () => _spotifyService.getAlbumTracks(albumId, offset: pageOffset, limit: limit)));
+        }
+
+        final chunkResults = await Future.wait(chunkFutures);
+        for (final page in chunkResults) {
+          final pageItems = page['items'] as List? ?? const [];
+          final extracted = <Map<String, dynamic>>[
+            for (final item in pageItems)
+              if (item is Map<String, dynamic>) Map<String, dynamic>.from(item)
+          ];
+          allTracks.addAll(extracted);
+        }
       }
     }
 
@@ -1614,23 +1622,31 @@ class SpotifyProvider extends ChangeNotifier {
     }
 
     final total = (tracksSection['total'] as int?) ?? allTracks.length;
-    var offset = initialItems.length;
+    final initialOffset = initialItems.length;
+    const limit = 100; // Spotify playlist tracks limit is 100
 
-    while (offset < total) {
-      final page = await _guard(
-          () => _spotifyService.getPlaylistTracks(playlistId, offset: offset));
-      final pageItems = page['items'] as List? ?? const [];
-      if (pageItems.isEmpty) {
-        break;
-      }
-      for (final item in pageItems) {
-        if (item is Map<String, dynamic>) {
-          addTrackFromContainer(item);
+    if (initialOffset < total) {
+      // ⚡ Bolt: Use Future.wait to fetch independent pages concurrently in chunks of 5.
+      // This prevents the waterfall effect and reduces load time without hitting rate limits.
+      const chunkSize = 5;
+      for (int currentOffset = initialOffset; currentOffset < total; currentOffset += limit * chunkSize) {
+        final chunkFutures = <Future<Map<String, dynamic>>>[];
+        for (int i = 0; i < chunkSize; i++) {
+          final pageOffset = currentOffset + (i * limit);
+          if (pageOffset >= total) break;
+          chunkFutures.add(_guard(() =>
+              _spotifyService.getPlaylistTracks(playlistId, offset: pageOffset, limit: limit)));
         }
-      }
-      offset += pageItems.length;
-      if (page['next'] == null) {
-        break;
+
+        final chunkResults = await Future.wait(chunkFutures);
+        for (final page in chunkResults) {
+          final pageItems = page['items'] as List? ?? const [];
+          for (final item in pageItems) {
+            if (item is Map<String, dynamic>) {
+              addTrackFromContainer(item);
+            }
+          }
+        }
       }
     }
 


### PR DESCRIPTION
### 💡 What:
Replaced sequential `await` loops inside `fetchAlbumDetails` and `fetchPlaylistDetails` (in `lib/providers/spotify_provider.dart`) with concurrent `Future.wait` fetches, chunked in batches of 5. 

### 🎯 Why:
The original code fetched paginated tracks sequentially inside a `while` loop (waterfall effect), meaning a playlist with 500 tracks (5 pages) would wait for page 1 to finish before starting page 2, significantly increasing the time the user spends staring at a loading screen.

### 📊 Impact:
* **Load Time:** Reduces overall load time for large albums and playlists theoretically by up to 5x (the chunk size), transforming a sequential network bottleneck into a parallel operation.
* **Safety:** Chunking strictly restricts concurrent requests to 5, keeping it well within Spotify API rate limits (HTTP 429) while still realizing performance gains. Offsets are now computed mathematically rather than dynamically using array length, reducing the risk of overlap.

### 🔬 Measurement:
1. Open a very large Spotify playlist or album (>200 tracks).
2. Observe the initial library load time and the network trace in Flutter DevTools; the pagination requests should now be grouped and resolve considerably faster than the previous sequential waterfall pattern.

---
*PR created automatically by Jules for task [3032163805857728284](https://jules.google.com/task/3032163805857728284) started by @p2o51*