### PR TITLE
⚡ Bolt: [Performance] Batch image preloads with Future.wait

### DIFF
--- a/lib/managers/spotify_cache_manager.dart
+++ b/lib/managers/spotify_cache_manager.dart
@@ -19,12 +19,15 @@ class SpotifyCacheManager {
   static const int playlistCacheMaxSize = 30;
 
   // 使用 LRU 缓存限制内存使用
-  final LruCache<String, String> _imageCache =
-      LruCache(maxSize: imageCacheMaxSize);
-  final LruCache<String, Map<String, dynamic>> _albumCache =
-      LruCache(maxSize: albumCacheMaxSize);
-  final LruCache<String, Map<String, dynamic>> _playlistCache =
-      LruCache(maxSize: playlistCacheMaxSize);
+  final LruCache<String, String> _imageCache = LruCache(
+    maxSize: imageCacheMaxSize,
+  );
+  final LruCache<String, Map<String, dynamic>> _albumCache = LruCache(
+    maxSize: albumCacheMaxSize,
+  );
+  final LruCache<String, Map<String, dynamic>> _playlistCache = LruCache(
+    maxSize: playlistCacheMaxSize,
+  );
 
   // ============ 图片缓存 ============
 
@@ -54,12 +57,12 @@ class SpotifyCacheManager {
     List<String> imageUrls,
     BuildContext context,
   ) async {
-    final uncachedUrls =
-        imageUrls.where((url) => !isImageCached(url)).toList();
+    final uncachedUrls = imageUrls.where((url) => !isImageCached(url)).toList();
 
-    for (final url in uncachedUrls) {
-      await preloadImage(url, context);
-    }
+    // ⚡ Bolt: Use Future.wait to execute independent image preload requests concurrently.
+    // This avoids the waterfall effect of sequential awaiting, significantly
+    // reducing total load time for batches of images.
+    await Future.wait(uncachedUrls.map((url) => preloadImage(url, context)));
   }
 
   /// 清除图片缓存


### PR DESCRIPTION
💡 **What**: Refactored the `preloadImages` method in `SpotifyCacheManager` to use `Future.wait` instead of a sequential `for` loop.
🎯 **Why**: When preloading multiple uncached images (e.g., a batch of album covers), the previous implementation sequentially awaited each `preloadImage` call. This creates a waterfall effect where the network request for image N+1 does not begin until image N is completely downloaded and decoded. By using `Future.wait`, we dispatch all preload requests to the Dart event loop and underlying network layer concurrently, significantly reducing the total wall-clock time required to cache a batch of images.
📊 **Impact**: Total time to preload `N` images changes from roughly `O(N * avg_download_time)` to `O(max_download_time)`. This reduces blocking and improves UI responsiveness, especially when users scroll quickly through large lists of tracks or when initializing playback context with multiple upcoming tracks.
🔬 **Measurement**: 
1. Open the application and navigate to a view that triggers batch image preloading (e.g., a long playlist or album tracklist).
2. Using Flutter DevTools, observe the Network tab.
3. Before the change, network requests for images will appear staggered (a waterfall).
4. After the change, network requests for the uncached images in the batch will initiate simultaneously.

---
*PR created automatically by Jules for task [2535477303556987500](https://jules.google.com/task/2535477303556987500) started by @p2o51*