### PR TITLE
⚡ Bolt: Optimize batch image preloading with Future.wait

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-05-19 - [Optimize Flutter Provider Selector for High-Frequency Streams]
 **Learning:** When using `Selector` in Flutter with high-frequency streams (like audio playback `progressMs`), passing the raw rapidly changing value into the `builder` causes excessive widget rebuilds.
 **Action:** Calculate the stable derived state (e.g., `currentLineIndex`) *inside* the `selector` callback and return a snapshot containing only the derived state. Update `shouldRebuild` to compare this derived state, ensuring the UI only rebuilds when visually necessary (e.g., when the lyric line changes, not on every millisecond tick).
+
+## 2024-05-19 - Concurrent Image Preloading with Future.wait()
+**Learning:** Sequential `await` calls in a `for` loop, especially when used for operations like preloading multiple images over the network, cause a waterfall effect, significantly increasing load times.
+**Action:** Always batch iterative network requests like `precacheImage` or `preloadImage` concurrently using `await Future.wait()` to prevent blocking sequential execution.

--- a/lib/managers/spotify_cache_manager.dart
+++ b/lib/managers/spotify_cache_manager.dart
@@ -19,12 +19,15 @@ class SpotifyCacheManager {
   static const int playlistCacheMaxSize = 30;
 
   // 使用 LRU 缓存限制内存使用
-  final LruCache<String, String> _imageCache =
-      LruCache(maxSize: imageCacheMaxSize);
-  final LruCache<String, Map<String, dynamic>> _albumCache =
-      LruCache(maxSize: albumCacheMaxSize);
-  final LruCache<String, Map<String, dynamic>> _playlistCache =
-      LruCache(maxSize: playlistCacheMaxSize);
+  final LruCache<String, String> _imageCache = LruCache(
+    maxSize: imageCacheMaxSize,
+  );
+  final LruCache<String, Map<String, dynamic>> _albumCache = LruCache(
+    maxSize: albumCacheMaxSize,
+  );
+  final LruCache<String, Map<String, dynamic>> _playlistCache = LruCache(
+    maxSize: playlistCacheMaxSize,
+  );
 
   // ============ 图片缓存 ============
 
@@ -54,12 +57,10 @@ class SpotifyCacheManager {
     List<String> imageUrls,
     BuildContext context,
   ) async {
-    final uncachedUrls =
-        imageUrls.where((url) => !isImageCached(url)).toList();
+    final uncachedUrls = imageUrls.where((url) => !isImageCached(url)).toList();
 
-    for (final url in uncachedUrls) {
-      await preloadImage(url, context);
-    }
+    // ⚡ Bolt: 性能优化 - 并发预加载图片，显著减少批量缓存时的整体耗时
+    await Future.wait(uncachedUrls.map((url) => preloadImage(url, context)));
   }
 
   /// 清除图片缓存


### PR DESCRIPTION
💡 **What:** Refactored `preloadImages` in `lib/managers/spotify_cache_manager.dart` to use `Future.wait` for concurrent image loading instead of sequential `await` within a `for` loop. Added a new journal entry to `.jules/bolt.md`.

🎯 **Why:** Sequential awaiting of independent network requests (like fetching and caching images) creates a waterfall effect, significantly increasing the total time required for the operation.

📊 **Impact:** Dramatically reduces the time it takes to preload batches of images (e.g., when caching playlist thumbnails). If caching 10 images sequentially takes 10 * x ms, doing it concurrently takes approximately 1 * x ms.

🔬 **Measurement:** Open a playlist or the recently played view that triggers batch image preloading. The images should appear significantly faster and the UI thread should experience less hitching during the caching background task.

---
*PR created automatically by Jules for task [5690525250337053590](https://jules.google.com/task/5690525250337053590) started by @p2o51*