### PR TITLE
⚡ Bolt: [performance improvement] concurrent image preloading in CacheManager

### DIFF
--- a/lib/managers/spotify_cache_manager.dart
+++ b/lib/managers/spotify_cache_manager.dart
@@ -19,12 +19,15 @@ class SpotifyCacheManager {
   static const int playlistCacheMaxSize = 30;
 
   // 使用 LRU 缓存限制内存使用
-  final LruCache<String, String> _imageCache =
-      LruCache(maxSize: imageCacheMaxSize);
-  final LruCache<String, Map<String, dynamic>> _albumCache =
-      LruCache(maxSize: albumCacheMaxSize);
-  final LruCache<String, Map<String, dynamic>> _playlistCache =
-      LruCache(maxSize: playlistCacheMaxSize);
+  final LruCache<String, String> _imageCache = LruCache(
+    maxSize: imageCacheMaxSize,
+  );
+  final LruCache<String, Map<String, dynamic>> _albumCache = LruCache(
+    maxSize: albumCacheMaxSize,
+  );
+  final LruCache<String, Map<String, dynamic>> _playlistCache = LruCache(
+    maxSize: playlistCacheMaxSize,
+  );
 
   // ============ 图片缓存 ============
 
@@ -54,12 +57,10 @@ class SpotifyCacheManager {
     List<String> imageUrls,
     BuildContext context,
   ) async {
-    final uncachedUrls =
-        imageUrls.where((url) => !isImageCached(url)).toList();
+    final uncachedUrls = imageUrls.where((url) => !isImageCached(url)).toList();
 
-    for (final url in uncachedUrls) {
-      await preloadImage(url, context);
-    }
+    // ⚡ Bolt: 性能优化 - 使用 Future.wait 并发预加载多张图片，避免在循环中依次等待导致的瀑布流延迟
+    await Future.wait(uncachedUrls.map((url) => preloadImage(url, context)));
   }
 
   /// 清除图片缓存


### PR DESCRIPTION
💡 **What:** Replaced the sequential `await preloadImage(url, context)` inside the `for` loop in `SpotifyCacheManager.preloadImages` with a concurrent `await Future.wait(...)`.

🎯 **Why:** To eliminate the "waterfall" effect where each image had to finish loading before the next one could begin. In a list view (like albums or playlists), preloading them sequentially introduced a massive bottleneck and increased the overall time spent on the preloading phase.

📊 **Impact:** Dramatically speeds up batch image preloading. If preloading 6 images sequentially took ~1200ms (200ms each), preloading them concurrently will now take approximately ~200ms total, improving perceived UI load speed by up to 6x.

🔬 **Measurement:** This can be verified by tracking the time it takes for a list of uncached tracks/albums to fully render their placeholder images, or by profiling the duration of `preloadImages` during network operations.

---
*PR created automatically by Jules for task [14035447958725441884](https://jules.google.com/task/14035447958725441884) started by @p2o51*