### PR TITLE
⚡ Bolt: Concurrent Image Preloading

### DIFF
--- a/lib/managers/spotify_cache_manager.dart
+++ b/lib/managers/spotify_cache_manager.dart
@@ -57,9 +57,8 @@ class SpotifyCacheManager {
     final uncachedUrls =
         imageUrls.where((url) => !isImageCached(url)).toList();
 
-    for (final url in uncachedUrls) {
-      await preloadImage(url, context);
-    }
+    // ⚡ Bolt: 性能优化 - 并发预加载图片，显著减少批量加载的整体耗时
+    await Future.wait(uncachedUrls.map((url) => preloadImage(url, context)));
   }
 
   /// 清除图片缓存


### PR DESCRIPTION
💡 **What:** Refactored `SpotifyCacheManager.preloadImages` to use `Future.wait` and map over the uncached URLs instead of using a `for` loop with sequential `await`.

🎯 **Why:** Previously, the `preloadImages` function was iterating through a list of uncached URLs and awaiting the preloading of each image sequentially. This creates a waterfall effect for network requests, significantly increasing the total time required to preload a batch of images. By using `Future.wait`, we launch all preload requests concurrently.

📊 **Impact:** Dramatically reduces the time it takes to preload multiple images, especially noticeable when preloading large batches of album covers or playlist images over slower network connections.

🔬 **Measurement:** The impact can be measured by profiling the duration of `preloadImages` execution before and after the change when loading a fresh list of URLs without existing cache.

---
*PR created automatically by Jules for task [4105413309509318884](https://jules.google.com/task/4105413309509318884) started by @p2o51*