### PR TITLE
⚡ Bolt: Concurrent playback state refresh

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-05-19 - [Optimize Flutter Provider Selector for High-Frequency Streams]
 **Learning:** When using `Selector` in Flutter with high-frequency streams (like audio playback `progressMs`), passing the raw rapidly changing value into the `builder` causes excessive widget rebuilds.
 **Action:** Calculate the stable derived state (e.g., `currentLineIndex`) *inside* the `selector` callback and return a snapshot containing only the derived state. Update `shouldRebuild` to compare this derived state, ensuring the UI only rebuilds when visually necessary (e.g., when the lyric line changes, not on every millisecond tick).
+
+## 2024-05-20 - Concurrent State Refresh After Action Triggers
+**Learning:** When user actions (e.g., triggering `playContext` or `playTrack`) require multiple independent state updates (e.g., refreshing both current track and playback queue) afterward, running those state fetchers sequentially compounds latency and delays UI responsiveness.
+**Action:** Always batch independent state refresh API calls triggered after mutations using `Future.wait` to reduce the total wait time by parallelizing network operations.

--- a/lib/providers/spotify_provider.dart
+++ b/lib/providers/spotify_provider.dart
@@ -1839,8 +1839,11 @@ class SpotifyProvider extends ChangeNotifier {
       await Future.delayed(const Duration(milliseconds: 500));
 
       // Refresh state after initiating play
-      await refreshCurrentTrack();
-      await refreshPlaybackQueue();
+      // ⚡ Bolt: 性能优化 - 并发刷新当前曲目和播放队列状态，减少 API 延迟串联造成的等待时间
+      await Future.wait([
+        refreshCurrentTrack(),
+        refreshPlaybackQueue(),
+      ]);
     } catch (e) {
       // debugPrint('播放 $type 失败: $e');
       await _handleApiError(e,
@@ -1897,8 +1900,11 @@ class SpotifyProvider extends ChangeNotifier {
       await Future.delayed(const Duration(milliseconds: 500));
 
       // Refresh state after initiating play
-      await refreshCurrentTrack();
-      await refreshPlaybackQueue();
+      // ⚡ Bolt: 性能优化 - 并发刷新当前曲目和播放队列状态，减少 API 延迟串联造成的等待时间
+      await Future.wait([
+        refreshCurrentTrack(),
+        refreshPlaybackQueue(),
+      ]);
     } catch (e) {
       // debugPrint('播放歌曲失败: $e');
       await _handleApiError(e, contextMessage: '播放歌曲', isUserInitiated: true);
@@ -1946,8 +1952,11 @@ class SpotifyProvider extends ChangeNotifier {
       await Future.delayed(const Duration(milliseconds: 500));
 
       // Refresh state after initiating play
-      await refreshCurrentTrack();
-      await refreshPlaybackQueue();
+      // ⚡ Bolt: 性能优化 - 并发刷新当前曲目和播放队列状态，减少 API 延迟串联造成的等待时间
+      await Future.wait([
+        refreshCurrentTrack(),
+        refreshPlaybackQueue(),
+      ]);
     } catch (e) {
       // debugPrint('在上下文中播放歌曲时出错: $e');
       await _handleApiError(e,
@@ -1992,8 +2001,11 @@ class SpotifyProvider extends ChangeNotifier {
       await Future.delayed(const Duration(milliseconds: 500));
 
       // Refresh state after initiating play
-      await refreshCurrentTrack();
-      await refreshPlaybackQueue();
+      // ⚡ Bolt: 性能优化 - 并发刷新当前曲目和播放队列状态，减少 API 延迟串联造成的等待时间
+      await Future.wait([
+        refreshCurrentTrack(),
+        refreshPlaybackQueue(),
+      ]);
     } catch (e) {
       await _handleApiError(e, contextMessage: '播放歌曲列表', isUserInitiated: true);
       if (e is SpotifyAuthException && e.code == 'RESTRICTED_DEVICE') {


### PR DESCRIPTION
💡 **What**: Refactored multiple playback initiation methods in `SpotifyProvider` (`playContext`, `playTrack`, `playTrackInContext`, `playTracks`) to use `Future.wait` to concurrently fetch the current track and the playback queue instead of awaiting them sequentially.

🎯 **Why**: When a user triggers playback, the app needs to refresh both the current track state and the playback queue to update the UI accurately. Awaiting these independent Spotify API calls sequentially compounds latency, introducing unnecessary delays in UI responsiveness after an action.

📊 **Impact**: Reduces the total post-action refresh delay by the duration of the faster API call (typically halving the waiting time), making the UI feel snappier immediately after triggering playback.

🔬 **Measurement**: Observe network timing and UI update speed after tapping to play a playlist, album, or track. Both the mini-player track info and the underlying queue should resolve and render noticeably faster.

---
*PR created automatically by Jules for task [2287023217959308572](https://jules.google.com/task/2287023217959308572) started by @p2o51*