### PR TITLE
⚡ Bolt: Implement concurrent batching for `getAllUserSavedTracks` in SpotifyService

### DIFF
--- a/lib/services/spotify_service.dart
+++ b/lib/services/spotify_service.dart
@@ -82,32 +82,37 @@ class SpotifyAuthService {
 
   // Add registerLifecycle method
   void _registerLifecycle() {
-    _appLifecycleObserver = _AppLifecycleObserver(onResume: () async {
-      await ensureFreshToken(); // 只续 token
-      if (_autoReconnectRemote) {
-        _setupConnectionListener();
-      }
-    });
+    _appLifecycleObserver = _AppLifecycleObserver(
+      onResume: () async {
+        await ensureFreshToken(); // 只续 token
+        if (_autoReconnectRemote) {
+          _setupConnectionListener();
+        }
+      },
+    );
     _binding.addObserver(_appLifecycleObserver!); // Add observer
   }
 
   /// 获取默认的 scope 列表
   List<String> get defaultScopes => [
-        'user-read-private',
-        'user-read-email',
-        'playlist-read-private',
-        'user-library-read',
-        'user-library-modify',
-        'user-read-currently-playing',
-        'user-read-playback-state',
-        'user-modify-playback-state',
-        'user-read-recently-played',
-        'app-remote-control', // 添加 Spotify SDK 官方推荐的核心权限
-      ];
+    'user-read-private',
+    'user-read-email',
+    'playlist-read-private',
+    'user-library-read',
+    'user-library-modify',
+    'user-read-currently-playing',
+    'user-read-playback-state',
+    'user-modify-playback-state',
+    'user-read-recently-played',
+    'app-remote-control', // 添加 Spotify SDK 官方推荐的核心权限
+  ];
 
   /// 简化版 _buildUri，放在类顶部工具区
   Uri _buildUri(String path, [Map<String, String>? query]) => Uri.https(
-      'api.spotify.com', '/v1$path', query?.isEmpty ?? true ? null : query);
+    'api.spotify.com',
+    '/v1$path',
+    query?.isEmpty ?? true ? null : query,
+  );
 
   /// 通用的网络重试包装器
   Future<T> _withNetworkRetry<T>(
@@ -131,9 +136,9 @@ class SpotifyAuthService {
         final errorString = e.toString().toLowerCase();
         final isRetryableNetworkError =
             errorString.contains('socketexception') ||
-                errorString.contains('timeoutexception') ||
-                errorString.contains('connection') ||
-                errorString.contains('clientexception');
+            errorString.contains('timeoutexception') ||
+            errorString.contains('connection') ||
+            errorString.contains('clientexception');
 
         if (retryCount < maxRetries && isRetryableNetworkError) {
           logger.d('$operationName: 网络错误，尝试第 $retryCount 次重试: $e');
@@ -145,20 +150,25 @@ class SpotifyAuthService {
         if (isRetryableNetworkError) {
           // 重试耗尽的网络错误
           throw SpotifyAuthException(
-              '$operationName 时出错: 网络连接失败，已尝试 $maxRetries 次',
-              code: 'NETWORK_RETRY_EXHAUSTED');
+            '$operationName 时出错: 网络连接失败，已尝试 $maxRetries 次',
+            code: 'NETWORK_RETRY_EXHAUSTED',
+          );
         } else {
           // 其他非网络错误
-          throw SpotifyAuthException('$operationName 时出错: $e',
-              code: 'OPERATION_FAILED_UNKNOWN');
+          throw SpotifyAuthException(
+            '$operationName 时出错: $e',
+            code: 'OPERATION_FAILED_UNKNOWN',
+          );
         }
       }
     }
 
     // 此处逻辑理论上不会到达，因为上面的循环会抛出异常或成功返回
     // 但为了完整性，保留一个最终的异常抛出
-    throw SpotifyAuthException('$operationName 时出错: 未知错误，重试逻辑未按预期工作',
-        code: 'RETRY_LOGIC_ERROR');
+    throw SpotifyAuthException(
+      '$operationName 时出错: 未知错误，重试逻辑未按预期工作',
+      code: 'RETRY_LOGIC_ERROR',
+    );
   }
 
   // 新增：创建认证请求头，可选是否包含 Content-Type
@@ -186,12 +196,10 @@ class SpotifyAuthService {
       // For GET requests, Content-Type is generally not needed.
       // Using _authHeaders with hasBody = false, or a simpler header map directly.
       final headers = await _authHeaders(
-          hasBody: false); // Or simply {'Authorization': 'Bearer $token'}
+        hasBody: false,
+      ); // Or simply {'Authorization': 'Bearer $token'}
 
-      final response = await http.get(
-        uri,
-        headers: headers,
-      );
+      final response = await http.get(uri, headers: headers);
 
       if (response.statusCode == 200 || response.statusCode == 201) {
         return jsonDecode(response.body);
@@ -210,8 +218,10 @@ class SpotifyAuthService {
   }
 
   /// 通用的 API PUT 请求方法
-  Future<Map<String, dynamic>?> apiPut(String endpoint,
-      {Map<String, dynamic>? body}) async {
+  Future<Map<String, dynamic>?> apiPut(
+    String endpoint, {
+    Map<String, dynamic>? body,
+  }) async {
     try {
       final token = await getAccessToken();
       if (token == null) {
@@ -280,7 +290,8 @@ class SpotifyAuthService {
 
   /// 监听连接状态
   void _setupConnectionListener() {
-    final isMobileTarget = defaultTargetPlatform == TargetPlatform.android ||
+    final isMobileTarget =
+        defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS;
     if (kIsWeb || !isMobileTarget) {
       // Spotify SDK connect/subscribe might not be supported or behave differently on other platforms.
@@ -383,8 +394,10 @@ class SpotifyAuthService {
 
       // We don't get expiresIn directly from getAccessToken(),
       // so we'll use a slightly reduced fixed duration.
-      await saveAuthResponse(newTok,
-          expiresInSeconds: 55 * 60); // 55 minutes in seconds
+      await saveAuthResponse(
+        newTok,
+        expiresInSeconds: 55 * 60,
+      ); // 55 minutes in seconds
       onTokenRefreshed?.call();
       return newTok;
     } catch (sdkError) {
@@ -400,25 +413,33 @@ class SpotifyAuthService {
           errorString.contains('timeout') ||
           errorString.contains('network') ||
           errorString.contains('connection')) {
-        throw SpotifyAuthException('网络连接异常，无法刷新访问令牌',
-            code: 'TOKEN_REFRESH_FAILED_NETWORK');
+        throw SpotifyAuthException(
+          '网络连接异常，无法刷新访问令牌',
+          code: 'TOKEN_REFRESH_FAILED_NETWORK',
+        );
       }
 
       if (errorString.contains('CONFIG_ERROR') ||
           errorString.contains('Could not find config')) {
-        throw SpotifyAuthException('Spotify SDK 配置错误: $sdkError',
-            code: 'CONFIG_ERROR');
+        throw SpotifyAuthException(
+          'Spotify SDK 配置错误: $sdkError',
+          code: 'CONFIG_ERROR',
+        );
       }
 
       if (!kIsWeb &&
           defaultTargetPlatform == TargetPlatform.iOS &&
           errorString.contains('Connection attempt failed')) {
-        throw SpotifyAuthException('iOS 连接 Spotify 失败，请重试',
-            code: 'IOS_CONNECTION_FAILED');
+        throw SpotifyAuthException(
+          'iOS 连接 Spotify 失败，请重试',
+          code: 'IOS_CONNECTION_FAILED',
+        );
       }
 
-      throw SpotifyAuthException('刷新访问令牌失败: $sdkError',
-          code: 'TOKEN_REFRESH_FAILED');
+      throw SpotifyAuthException(
+        '刷新访问令牌失败: $sdkError',
+        code: 'TOKEN_REFRESH_FAILED',
+      );
     } finally {
       _isRefreshingToken = false;
     }
@@ -428,7 +449,8 @@ class SpotifyAuthService {
   Future<bool> connectRemoteIfNeeded() async {
     // 直接返回 true，暂时跳过 Remote 连接，专注于 Web API
     logger.d(
-        'connectRemoteIfNeeded: Skipped, returning true directly for Web API testing.');
+      'connectRemoteIfNeeded: Skipped, returning true directly for Web API testing.',
+    );
     return true;
     /*
     try {
@@ -483,8 +505,10 @@ class SpotifyAuthService {
 
         if (accessToken.isNotEmpty) {
           // Use the same saving mechanism as ensureFreshToken
-          await saveAuthResponse(accessToken,
-              expiresInSeconds: 55 * 60); // 55 minutes
+          await saveAuthResponse(
+            accessToken,
+            expiresInSeconds: 55 * 60,
+          ); // 55 minutes
           onTokenRefreshed?.call(); // 登录成功后也通知
           return accessToken;
         } else {
@@ -498,32 +522,43 @@ class SpotifyAuthService {
           throw SpotifyAuthException('登录被用户取消', code: 'AUTH_CANCELLED');
         } else if (sdkError is PlatformException &&
             (sdkError.code == 'AUTHENTICATION_SERVICE_UNAVAILABLE' ||
-                sdkError.message
-                        ?.contains('AUTHENTICATION_SERVICE_UNAVAILABLE') ==
+                sdkError.message?.contains(
+                      'AUTHENTICATION_SERVICE_UNAVAILABLE',
+                    ) ==
                     true ||
-                '${sdkError.details}'.contains('AUTHENTICATION_SERVICE_UNAVAILABLE') ||
+                '${sdkError.details}'.contains(
+                  'AUTHENTICATION_SERVICE_UNAVAILABLE',
+                ) ||
                 errorString.contains('AUTHENTICATION_SERVICE_UNAVAILABLE'))) {
           throw SpotifyAuthException(
-              'Spotify 授权服务暂时不可用，请稍后重试或检查是否安装/登录最新版本的 Spotify 应用。',
-              code: 'AUTH_SERVICE_UNAVAILABLE');
+            'Spotify 授权服务暂时不可用，请稍后重试或检查是否安装/登录最新版本的 Spotify 应用。',
+            code: 'AUTH_SERVICE_UNAVAILABLE',
+          );
         } else if (errorString.contains('CONFIG_ERROR') ||
             errorString.contains('Could not find config')) {
           throw SpotifyAuthException(
-              '登录失败：Spotify SDK 配置错误，请检查 AndroidManifest/Info.plist',
-              code: 'CONFIG_ERROR');
+            '登录失败：Spotify SDK 配置错误，请检查 AndroidManifest/Info.plist',
+            code: 'CONFIG_ERROR',
+          );
         } else if (errorString.contains('Could not authenticate client')) {
-          throw SpotifyAuthException('登录失败：无效的 Client ID 或 Redirect URI',
-              code: 'AUTH_FAILED');
+          throw SpotifyAuthException(
+            '登录失败：无效的 Client ID 或 Redirect URI',
+            code: 'AUTH_FAILED',
+          );
         } else if (!kIsWeb &&
             defaultTargetPlatform == TargetPlatform.iOS &&
             errorString.contains('Connection attempt failed')) {
           // iOS特有的连接失败处理
           logger.w('iOS登录时遇到连接失败，尝试重新配置: $errorString');
-          throw SpotifyAuthException('iOS登录失败：请确保已安装Spotify应用并重试',
-              code: 'IOS_CONNECTION_FAILED');
+          throw SpotifyAuthException(
+            'iOS登录失败：请确保已安装Spotify应用并重试',
+            code: 'IOS_CONNECTION_FAILED',
+          );
         }
-        throw SpotifyAuthException('登录时发生未知错误: $sdkError',
-            code: 'UNKNOWN_SDK_ERROR');
+        throw SpotifyAuthException(
+          '登录时发生未知错误: $sdkError',
+          code: 'UNKNOWN_SDK_ERROR',
+        );
       }
     } catch (e) {
       if (e is SpotifyAuthException) rethrow;
@@ -532,8 +567,10 @@ class SpotifyAuthService {
   }
 
   /// 保存认证响应到安全存储
-  Future<void> saveAuthResponse(String accessToken,
-      {int expiresInSeconds = 3600}) async {
+  Future<void> saveAuthResponse(
+    String accessToken, {
+    int expiresInSeconds = 3600,
+  }) async {
     // Default to 1 hour if not specified
     try {
       await Future.wait([
@@ -616,74 +653,73 @@ class SpotifyAuthService {
 
   /// 获取当前正在播放的曲目
   Future<Map<String, dynamic>?> getCurrentlyPlayingTrack() async {
-    return await _withNetworkRetry<Map<String, dynamic>?>(
-      () async {
-        final headers =
-            await _authHeaders(hasBody: false); // GET request, no body
-        final response = await http.get(
-          Uri.parse('https://api.spotify.com/v1/me/player/currently-playing'),
-          headers: headers,
+    return await _withNetworkRetry<Map<String, dynamic>?>(() async {
+      final headers = await _authHeaders(
+        hasBody: false,
+      ); // GET request, no body
+      final response = await http.get(
+        Uri.parse('https://api.spotify.com/v1/me/player/currently-playing'),
+        headers: headers,
+      );
+
+      // 如果返回204表示当前没有播放内容
+      if (response.statusCode == 204) {
+        return null;
+      }
+
+      if (response.statusCode != 200) {
+        throw SpotifyAuthException(
+          '获取当前播放曲目失败: ${response.body}',
+          code: response.statusCode.toString(),
         );
+      }
 
-        // 如果返回204表示当前没有播放内容
-        if (response.statusCode == 204) {
-          return null;
-        }
-
-        if (response.statusCode != 200) {
-          throw SpotifyAuthException(
-            '获取当前播放曲目失败: ${response.body}',
-            code: response.statusCode.toString(),
-          );
-        }
-
-        return json.decode(response.body);
-      },
-      operationName: '获取当前播放曲目',
-    );
+      return json.decode(response.body);
+    }, operationName: '获取当前播放曲目');
   }
 
   /// 获取播放状态
   Future<Map<String, dynamic>> getPlaybackState() async {
-    return await _withNetworkRetry<Map<String, dynamic>>(
-      () async {
-        final headers =
-            await _authHeaders(hasBody: false); // GET request, no body
-        final response = await http.get(
-          Uri.parse('https://api.spotify.com/v1/me/player'),
-          headers: headers,
+    return await _withNetworkRetry<Map<String, dynamic>>(() async {
+      final headers = await _authHeaders(
+        hasBody: false,
+      ); // GET request, no body
+      final response = await http.get(
+        Uri.parse('https://api.spotify.com/v1/me/player'),
+        headers: headers,
+      );
+
+      // 如果返回204表示当前没有活动设备
+      if (response.statusCode == 204) {
+        return {};
+      }
+
+      if (response.statusCode != 200) {
+        throw SpotifyAuthException(
+          '获取播放状态失败: ${response.body}',
+          code: response.statusCode.toString(),
         );
+      }
 
-        // 如果返回204表示当前没有活动设备
-        if (response.statusCode == 204) {
-          return {};
-        }
-
-        if (response.statusCode != 200) {
-          throw SpotifyAuthException(
-            '获取播放状态失败: ${response.body}',
-            code: response.statusCode.toString(),
-          );
-        }
-
-        return json.decode(response.body);
-      },
-      operationName: '获取播放状态',
-    );
+      return json.decode(response.body);
+    }, operationName: '获取播放状态');
   }
 
   /// 创建辅助方法处理API请求，先不带device_id，失败时再补充
-  Future<void> _withDevice(String path,
-      {String method = 'PUT',
-      Map<String, String> query = const {},
-      Map<String, dynamic>? body}) async {
+  Future<void> _withDevice(
+    String path, {
+    String method = 'PUT',
+    Map<String, String> query = const {},
+    Map<String, dynamic>? body,
+  }) async {
     logger.d("===== SPOTIFY API DEBUG (_withDevice) =====");
     String attemptType = "Initial";
 
     try {
       Future<http.Response> makeRequest(String deviceIdQuerySuffix) async {
-        final fullPath =
-            deviceIdQuerySuffix.isEmpty ? path : '$path$deviceIdQuerySuffix';
+        final fullPath = deviceIdQuerySuffix.isEmpty
+            ? path
+            : '$path$deviceIdQuerySuffix';
         final currentUri = _buildUri(fullPath, query);
         // Note: _buildUri already incorporates query parameters passed to it.
         // If device_id is part of the `query` map, it will be included.
@@ -698,12 +734,18 @@ class SpotifyAuthService {
         logger.d("[$attemptType Attempt] Headers: $headers");
 
         if (method == 'POST') {
-          return await http.post(currentUri,
-              headers: headers, body: body != null ? jsonEncode(body) : null);
+          return await http.post(
+            currentUri,
+            headers: headers,
+            body: body != null ? jsonEncode(body) : null,
+          );
         } else {
           // Default to PUT
-          return await http.put(currentUri,
-              headers: headers, body: body != null ? jsonEncode(body) : null);
+          return await http.put(
+            currentUri,
+            headers: headers,
+            body: body != null ? jsonEncode(body) : null,
+          );
         }
       }
 
@@ -724,7 +766,8 @@ class SpotifyAuthService {
 
       if (isSuccessStatusCode) {
         logger.d(
-            "[$attemptType Attempt] Successfully processed ($method $path) with status ${r.statusCode}.");
+          "[$attemptType Attempt] Successfully processed ($method $path) with status ${r.statusCode}.",
+        );
         logger.d("===== SPOTIFY API DEBUG (_withDevice) END =====");
         return;
       }
@@ -737,33 +780,40 @@ class SpotifyAuthService {
 
       // If initial attempt failed with other 4xx/5xx, try with device_id
       logger.d(
-          "[$attemptType Attempt] Failed (${r.statusCode}). Trying to find active device for retry...");
+        "[$attemptType Attempt] Failed (${r.statusCode}). Trying to find active device for retry...",
+      );
       attemptType = "Retry";
 
       final devices = await getAvailableDevices();
       logger.d("[$attemptType] Found ${devices.length} devices.");
       for (final d in devices) {
         logger.d(
-            "[$attemptType] Device: ${d['name']} (${d['id']}), Active: ${d['is_active']}");
+          "[$attemptType] Device: ${d['name']} (${d['id']}), Active: ${d['is_active']}",
+        );
       }
 
-      final activeDevice =
-          devices.firstWhereOrNull((d) => d['is_active'] == true);
+      final activeDevice = devices.firstWhereOrNull(
+        (d) => d['is_active'] == true,
+      );
       String? targetDeviceIdForRetry;
 
       if (activeDevice != null) {
         targetDeviceIdForRetry = activeDevice['id'] as String?;
         logger.d(
-            "[$attemptType] Using active device: ${activeDevice['name']} ($targetDeviceIdForRetry)");
+          "[$attemptType] Using active device: ${activeDevice['name']} ($targetDeviceIdForRetry)",
+        );
       } else if (devices.isNotEmpty) {
         targetDeviceIdForRetry = devices.first['id'] as String?;
         logger.d(
-            "[$attemptType] No active device, using first available: ${devices.first['name']} ($targetDeviceIdForRetry)");
+          "[$attemptType] No active device, using first available: ${devices.first['name']} ($targetDeviceIdForRetry)",
+        );
       } else {
         logger.d("[$attemptType] No devices available for retry.");
         logger.d("===== SPOTIFY API DEBUG (_withDevice) END =====");
-        throw SpotifyAuthException('找不到可用播放设备 (重试也无设备)',
-            code: 'NO_DEVICE_ON_RETRY');
+        throw SpotifyAuthException(
+          '找不到可用播放设备 (重试也无设备)',
+          code: 'NO_DEVICE_ON_RETRY',
+        );
       }
 
       if (targetDeviceIdForRetry != null) {
@@ -782,14 +832,18 @@ class SpotifyAuthService {
         logger.d("[$attemptType Attempt] Headers: $headersForRetry");
 
         if (method == 'POST') {
-          r = await http.post(retryUri,
-              headers: headersForRetry,
-              body: body != null ? jsonEncode(body) : null);
+          r = await http.post(
+            retryUri,
+            headers: headersForRetry,
+            body: body != null ? jsonEncode(body) : null,
+          );
         } else {
           // Default to PUT
-          r = await http.put(retryUri,
-              headers: headersForRetry,
-              body: body != null ? jsonEncode(body) : null);
+          r = await http.put(
+            retryUri,
+            headers: headersForRetry,
+            body: body != null ? jsonEncode(body) : null,
+          );
         }
 
         logger.d("[$attemptType Attempt] Response Status: ${r.statusCode}");
@@ -802,22 +856,29 @@ class SpotifyAuthService {
         // 重试时也要包含200作为成功状态码
         if (r.statusCode == 204 || r.statusCode == 202 || r.statusCode == 200) {
           logger.d(
-              "[$attemptType Attempt] Successfully processed ($method $path) with status ${r.statusCode}.");
+            "[$attemptType Attempt] Successfully processed ($method $path) with status ${r.statusCode}.",
+          );
           logger.d("===== SPOTIFY API DEBUG (_withDevice) END =====");
           return;
         }
         logger.d(
-            "[$attemptType Attempt] Failed (${r.statusCode}). Error response: ${r.body}");
+          "[$attemptType Attempt] Failed (${r.statusCode}). Error response: ${r.body}",
+        );
         logger.d("===== SPOTIFY API DEBUG (_withDevice) END =====");
-        throw SpotifyAuthException('控制失败 (重试后): ${r.body}',
-            code: r.statusCode.toString());
+        throw SpotifyAuthException(
+          '控制失败 (重试后): ${r.body}',
+          code: r.statusCode.toString(),
+        );
       }
       // Should not be reached if targetDeviceIdForRetry was null due to earlier throw, but as a safeguard:
       logger.d(
-          "[$attemptType] Retry attempt not made as no target device ID was found.");
+        "[$attemptType] Retry attempt not made as no target device ID was found.",
+      );
       logger.d("===== SPOTIFY API DEBUG (_withDevice) END =====");
-      throw SpotifyAuthException('重试尝试未进行，无目标设备ID',
-          code: 'RETRY_NOT_ATTEMPTED');
+      throw SpotifyAuthException(
+        '重试尝试未进行，无目标设备ID',
+        code: 'RETRY_NOT_ATTEMPTED',
+      );
     } catch (e) {
       logger.d("Error in _withDevice: $e");
       if (e is SpotifyAuthException) {
@@ -825,7 +886,8 @@ class SpotifyAuthService {
         rethrow;
       }
       logger.d(
-          "===== SPOTIFY API DEBUG (_withDevice) END (Unknown Exception) =====");
+        "===== SPOTIFY API DEBUG (_withDevice) END (Unknown Exception) =====",
+      );
       throw SpotifyAuthException('_withDevice 内部错误: $e');
     }
   }
@@ -909,8 +971,9 @@ class SpotifyAuthService {
   /// 检查歌曲是否已保存到用户的音乐库
   Future<bool> isTrackSaved(String trackId) async {
     try {
-      final headers =
-          await _authHeaders(hasBody: false); // GET request, no body
+      final headers = await _authHeaders(
+        hasBody: false,
+      ); // GET request, no body
       final response = await http.get(
         Uri.parse('https://api.spotify.com/v1/me/tracks/contains?ids=$trackId'),
         headers: headers,
@@ -933,13 +996,14 @@ class SpotifyAuthService {
   /// 将歌曲保存到用户的音乐库
   Future<void> saveTrack(String trackId) async {
     try {
-      final headers =
-          await _authHeaders(hasBody: true); // PUT request with body
+      final headers = await _authHeaders(
+        hasBody: true,
+      ); // PUT request with body
       final response = await http.put(
         Uri.parse('https://api.spotify.com/v1/me/tracks'),
         headers: headers,
         body: json.encode({
-          'ids': [trackId]
+          'ids': [trackId],
         }),
       );
 
@@ -957,13 +1021,14 @@ class SpotifyAuthService {
   /// 从用户的音乐库中移除歌曲
   Future<void> removeTrack(String trackId) async {
     try {
-      final headers =
-          await _authHeaders(hasBody: true); // DELETE request with body
+      final headers = await _authHeaders(
+        hasBody: true,
+      ); // DELETE request with body
       final response = await http.delete(
         Uri.parse('https://api.spotify.com/v1/me/tracks'),
         headers: headers,
         body: json.encode({
-          'ids': [trackId]
+          'ids': [trackId],
         }),
       );
 
@@ -997,8 +1062,9 @@ class SpotifyAuthService {
   /// 获取播放队列
   Future<Map<String, dynamic>> getPlaybackQueue() async {
     try {
-      final headers =
-          await _authHeaders(hasBody: false); // GET request, no body
+      final headers = await _authHeaders(
+        hasBody: false,
+      ); // GET request, no body
       final response = await http.get(
         Uri.parse('https://api.spotify.com/v1/me/player/queue'),
         headers: headers,
@@ -1022,7 +1088,8 @@ class SpotifyAuthService {
   Future<void> setRepeatMode(String mode) async {
     try {
       final headers = await _authHeaders(
-          hasBody: false); // PUT request, no body (query param)
+        hasBody: false,
+      ); // PUT request, no body (query param)
       final response = await http.put(
         Uri.parse('https://api.spotify.com/v1/me/player/repeat?state=$mode'),
         headers: headers,
@@ -1045,7 +1112,8 @@ class SpotifyAuthService {
   Future<void> setShuffle(bool state) async {
     try {
       final headers = await _authHeaders(
-          hasBody: false); // PUT request, no body (query param)
+        hasBody: false,
+      ); // PUT request, no body (query param)
       final response = await http.put(
         Uri.parse('https://api.spotify.com/v1/me/player/shuffle?state=$state'),
         headers: headers,
@@ -1067,11 +1135,13 @@ class SpotifyAuthService {
   /// 获取最近播放记录
   Future<Map<String, dynamic>> getRecentlyPlayed({int limit = 50}) async {
     try {
-      final headers =
-          await _authHeaders(hasBody: false); // GET request, no body
+      final headers = await _authHeaders(
+        hasBody: false,
+      ); // GET request, no body
       final response = await http.get(
         Uri.parse(
-            'https://api.spotify.com/v1/me/player/recently-played?limit=$limit'),
+          'https://api.spotify.com/v1/me/player/recently-played?limit=$limit',
+        ),
         headers: headers,
       );
 
@@ -1089,8 +1159,9 @@ class SpotifyAuthService {
   }
 
   /// Fetches the raw recently played track items from Spotify API.
-  Future<List<Map<String, dynamic>>> getRecentlyPlayedRawTracks(
-      {int limit = 50}) async {
+  Future<List<Map<String, dynamic>>> getRecentlyPlayedRawTracks({
+    int limit = 50,
+  }) async {
     final response = await apiGet('/me/player/recently-played?limit=$limit');
     // Return the list of items directly, or empty list if null
     return List<Map<String, dynamic>>.from(response['items'] ?? []);
@@ -1099,8 +1170,9 @@ class SpotifyAuthService {
   /// 获取播放列表详情
   Future<Map<String, dynamic>> getPlaylist(String playlistId) async {
     try {
-      final headers =
-          await _authHeaders(hasBody: false); // GET request, no body
+      final headers = await _authHeaders(
+        hasBody: false,
+      ); // GET request, no body
       final response = await http.get(
         Uri.parse('https://api.spotify.com/v1/playlists/$playlistId'),
         headers: headers,
@@ -1122,8 +1194,9 @@ class SpotifyAuthService {
   /// 获取专辑详情
   Future<Map<String, dynamic>> getAlbum(String albumId) async {
     try {
-      final headers =
-          await _authHeaders(hasBody: false); // GET request, no body
+      final headers = await _authHeaders(
+        hasBody: false,
+      ); // GET request, no body
       final response = await http.get(
         Uri.parse('https://api.spotify.com/v1/albums/$albumId'),
         headers: headers,
@@ -1143,12 +1216,16 @@ class SpotifyAuthService {
   }
 
   /// 获取播放列表曲目（分页）。
-  Future<Map<String, dynamic>> getPlaylistTracks(String playlistId,
-      {int offset = 0, int limit = 100}) async {
+  Future<Map<String, dynamic>> getPlaylistTracks(
+    String playlistId, {
+    int offset = 0,
+    int limit = 100,
+  }) async {
     try {
       final headers = await _authHeaders(hasBody: false);
       final uri = Uri.parse(
-          'https://api.spotify.com/v1/playlists/$playlistId/tracks?offset=$offset&limit=$limit');
+        'https://api.spotify.com/v1/playlists/$playlistId/tracks?offset=$offset&limit=$limit',
+      );
       final response = await http.get(uri, headers: headers);
 
       if (response.statusCode != 200) {
@@ -1165,12 +1242,16 @@ class SpotifyAuthService {
   }
 
   /// 获取专辑的曲目列表（分页）。
-  Future<Map<String, dynamic>> getAlbumTracks(String albumId,
-      {int offset = 0, int limit = 50}) async {
+  Future<Map<String, dynamic>> getAlbumTracks(
+    String albumId, {
+    int offset = 0,
+    int limit = 50,
+  }) async {
     try {
       final headers = await _authHeaders(hasBody: false);
       final uri = Uri.parse(
-          'https://api.spotify.com/v1/albums/$albumId/tracks?offset=$offset&limit=$limit');
+        'https://api.spotify.com/v1/albums/$albumId/tracks?offset=$offset&limit=$limit',
+      );
       final response = await http.get(uri, headers: headers);
 
       if (response.statusCode != 200) {
@@ -1189,8 +1270,9 @@ class SpotifyAuthService {
   /// 获取可用设备列表
   Future<List<Map<String, dynamic>>> getAvailableDevices() async {
     try {
-      final headers =
-          await _authHeaders(hasBody: false); // GET request, no body
+      final headers = await _authHeaders(
+        hasBody: false,
+      ); // GET request, no body
       final response = await http.get(
         Uri.parse('https://api.spotify.com/v1/me/player/devices'),
         headers: headers,
@@ -1213,8 +1295,9 @@ class SpotifyAuthService {
   /// 转移播放到指定设备
   Future<void> transferPlayback(String deviceId, {bool play = false}) async {
     try {
-      final headers =
-          await _authHeaders(hasBody: true); // PUT request with body
+      final headers = await _authHeaders(
+        hasBody: true,
+      ); // PUT request with body
       final response = await http.put(
         Uri.parse('https://api.spotify.com/v1/me/player'),
         headers: headers,
@@ -1242,8 +1325,9 @@ class SpotifyAuthService {
     String? deviceId,
   }) async {
     try {
-      final headers =
-          await _authHeaders(hasBody: true); // PUT request with body
+      final headers = await _authHeaders(
+        hasBody: true,
+      ); // PUT request with body
       final body = {
         'context_uri': contextUri,
         if (offsetIndex != null) 'offset': {'position': offsetIndex},
@@ -1268,13 +1352,11 @@ class SpotifyAuthService {
   }
 
   /// 播放单曲
-  Future<void> playTrack({
-    required String trackUri,
-    String? deviceId,
-  }) async {
+  Future<void> playTrack({required String trackUri, String? deviceId}) async {
     try {
-      final headers =
-          await _authHeaders(hasBody: true); // PUT request with body
+      final headers = await _authHeaders(
+        hasBody: true,
+      ); // PUT request with body
       final body = {
         'uris': [trackUri],
       };
@@ -1304,11 +1386,10 @@ class SpotifyAuthService {
     String? deviceId,
   }) async {
     try {
-      final headers =
-          await _authHeaders(hasBody: true); // PUT request with body
-      final Map<String, dynamic> body = {
-        'uris': trackUris,
-      };
+      final headers = await _authHeaders(
+        hasBody: true,
+      ); // PUT request with body
+      final Map<String, dynamic> body = {'uris': trackUris};
 
       // 如果指定了偏移量，添加 offset 参数
       if (offsetIndex != null) {
@@ -1371,7 +1452,8 @@ class SpotifyAuthService {
       // 对于非受限设备，使用标准播放方式
       final trackResponse = await http.get(
         Uri.parse(
-            'https://api.spotify.com/v1/tracks/${trackUri.split(':').last}'),
+          'https://api.spotify.com/v1/tracks/${trackUri.split(':').last}',
+        ),
         headers: getHeaders, // Use getHeaders
       );
 
@@ -1388,9 +1470,7 @@ class SpotifyAuthService {
       final playHeaders = await _authHeaders(hasBody: true);
 
       // 构建播放请求
-      Map<String, dynamic> body = {
-        'context_uri': contextUri,
-      };
+      Map<String, dynamic> body = {'context_uri': contextUri};
 
       // Prefer explicit position when provided to disambiguate duplicates
       if (offsetIndex != null) {
@@ -1416,7 +1496,8 @@ class SpotifyAuthService {
             body['offset'] = {'position': trackNumber - 1};
             final retryResponse = await http.put(
               Uri.parse(
-                  'https://api.spotify.com/v1/me/player/play$queryParams'),
+                'https://api.spotify.com/v1/me/player/play$queryParams',
+              ),
               headers: playHeaders,
               body: json.encode(body),
             );
@@ -1469,7 +1550,8 @@ class SpotifyAuthService {
   Future<void> setVolume(int volumePercent, {String? deviceId}) async {
     try {
       final headers = await _authHeaders(
-          hasBody: false); // PUT request, no body (query params)
+        hasBody: false,
+      ); // PUT request, no body (query params)
 
       // 构建查询参数
       final queryParams = {
@@ -1513,8 +1595,13 @@ class SpotifyAuthService {
   }
 
   /// Search for items on Spotify
-  Future<Map<String, dynamic>> search(String query, List<String> types,
-      {int limit = 20, int offset = 0, String? market}) async {
+  Future<Map<String, dynamic>> search(
+    String query,
+    List<String> types, {
+    int limit = 20,
+    int offset = 0,
+    String? market,
+  }) async {
     if (query.trim().isEmpty) {
       throw SpotifyAuthException('Search query cannot be empty.');
     }
@@ -1545,7 +1632,8 @@ class SpotifyAuthService {
       final headers = await _authHeaders(hasBody: false);
       final response = await http.get(
         Uri.parse(
-            'https://api.spotify.com/v1/me/tracks?offset=$offset&limit=$limit'),
+          'https://api.spotify.com/v1/me/tracks?offset=$offset&limit=$limit',
+        ),
         headers: headers,
       );
 
@@ -1573,40 +1661,74 @@ class SpotifyAuthService {
     final allTracks = <Map<String, dynamic>>[];
     int offset = 0;
     const limit = 50;
+    const batchSize =
+        5; // Spotify API pagination in this application can safely batch up to 5 concurrent requests
     int? totalTracks;
 
     while (true) {
       try {
         final headers = await _authHeaders(hasBody: false);
-        final response = await http.get(
-          Uri.parse(
-              'https://api.spotify.com/v1/me/tracks?offset=$offset&limit=$limit'),
-          headers: headers,
-        );
 
-        if (response.statusCode != 200) {
-          throw SpotifyAuthException(
-            '获取收藏曲目失败: ${response.body}',
-            code: response.statusCode.toString(),
+        // Prepare batch requests
+        final futures = <Future<http.Response>>[];
+        for (int i = 0; i < batchSize; i++) {
+          final currentOffset = offset + (i * limit);
+          if (currentOffset >= maxTracks) break;
+          if (totalTracks != null && currentOffset >= totalTracks) break;
+
+          futures.add(
+            http.get(
+              Uri.parse(
+                'https://api.spotify.com/v1/me/tracks?offset=$currentOffset&limit=$limit',
+              ),
+              headers: headers,
+            ),
           );
         }
 
-        final data = json.decode(response.body);
-        totalTracks ??= data['total'] as int?;
-        final items = List<Map<String, dynamic>>.from(data['items'] ?? []);
+        if (futures.isEmpty) break;
 
-        if (items.isEmpty) break;
+        // Execute batch concurrently
+        final responses = await Future.wait(futures);
 
-        allTracks.addAll(items);
-        onProgress?.call(allTracks.length, totalTracks);
+        bool hasMore = true;
+        for (final response in responses) {
+          if (response.statusCode != 200) {
+            throw SpotifyAuthException(
+              '获取收藏曲目失败: ${response.body}',
+              code: response.statusCode.toString(),
+            );
+          }
 
-        if (allTracks.length >= maxTracks || data['next'] == null) break;
+          final data = json.decode(response.body);
+          totalTracks ??= data['total'] as int?;
+          final items = List<Map<String, dynamic>>.from(data['items'] ?? []);
 
-        offset += limit;
+          if (items.isEmpty) {
+            hasMore = false;
+            break;
+          }
+
+          allTracks.addAll(items);
+          onProgress?.call(allTracks.length, totalTracks);
+
+          if (allTracks.length >= maxTracks || data['next'] == null) {
+            hasMore = false;
+            break;
+          }
+        }
+
+        if (!hasMore ||
+            allTracks.length >= maxTracks ||
+            (totalTracks != null && allTracks.length >= totalTracks)) {
+          break;
+        }
+
+        offset += limit * batchSize;
 
         // 添加延迟防止触发 Spotify API 速率限制（180次/30秒）
-        // 每次请求后等待 200ms，确保不会超过限额
-        await Future.delayed(const Duration(milliseconds: 200));
+        // Batch multiplier delay implementation according to the memory guidelines
+        await Future.delayed(Duration(milliseconds: 200 * batchSize));
       } catch (e) {
         if (e is SpotifyAuthException) rethrow;
         throw SpotifyAuthException('获取收藏曲目时出错: $e');


### PR DESCRIPTION
💡 **What**: Refactored the sequential API fetching loop in `getAllUserSavedTracks` (within `SpotifyAuthService`) to use concurrent batched requests with `Future.wait`. It now safely fetches 5 requests at a time.

🎯 **Why**: Previously, the application fetched a user's entire library of saved tracks sequentially (50 tracks at a time). For a user with 5,000 saved tracks, this resulted in 100 sequential round-trips to the Spotify API, creating a massive artificial bottleneck. By batching up to 5 concurrent requests, network latency is parallelized without triggering Spotify's rate limits. 

📊 **Impact**: Reduces total network latency for fetching saved tracks by theoretically ~80%.

🔬 **Measurement**: Time the execution duration of `TimeMachineService.getTodayMemories()` (which calls `getAllUserSavedTracks`) with a large music library before and after this change. The total fetch time should decrease significantly.

---
*PR created automatically by Jules for task [2225374306785822923](https://jules.google.com/task/2225374306785822923) started by @p2o51*