### PR TITLE
⚡ Bolt: [performance improvement] Optimize SpotifyCacheManager preloading

### DIFF
--- a/lib/managers/spotify_cache_manager.dart
+++ b/lib/managers/spotify_cache_manager.dart
@@ -19,12 +19,15 @@ class SpotifyCacheManager {
   static const int playlistCacheMaxSize = 30;
 
   // 使用 LRU 缓存限制内存使用
-  final LruCache<String, String> _imageCache =
-      LruCache(maxSize: imageCacheMaxSize);
-  final LruCache<String, Map<String, dynamic>> _albumCache =
-      LruCache(maxSize: albumCacheMaxSize);
-  final LruCache<String, Map<String, dynamic>> _playlistCache =
-      LruCache(maxSize: playlistCacheMaxSize);
+  final LruCache<String, String> _imageCache = LruCache(
+    maxSize: imageCacheMaxSize,
+  );
+  final LruCache<String, Map<String, dynamic>> _albumCache = LruCache(
+    maxSize: albumCacheMaxSize,
+  );
+  final LruCache<String, Map<String, dynamic>> _playlistCache = LruCache(
+    maxSize: playlistCacheMaxSize,
+  );
 
   // ============ 图片缓存 ============
 
@@ -54,12 +57,9 @@ class SpotifyCacheManager {
     List<String> imageUrls,
     BuildContext context,
   ) async {
-    final uncachedUrls =
-        imageUrls.where((url) => !isImageCached(url)).toList();
+    final uncachedUrls = imageUrls.where((url) => !isImageCached(url)).toList();
 
-    for (final url in uncachedUrls) {
-      await preloadImage(url, context);
-    }
+    await Future.wait(uncachedUrls.map((url) => preloadImage(url, context)));
   }
 
   /// 清除图片缓存


### PR DESCRIPTION
💡 **What**: Refactored `SpotifyCacheManager.preloadImages` to use `Future.wait` for executing `preloadImage` requests concurrently, replacing the previous sequential `for` loop that awaited each request individually.

🎯 **Why**: The previous implementation sequentially awaited each image load, causing a network waterfall effect where each image had to completely finish downloading and caching before the next one could begin. This significantly delayed the preloading process when fetching multiple images (e.g., when scrolling through a list or loading initial UI).

📊 **Impact**: Reduces total image preloading time from $O(n)$ (sum of all individual load times) to roughly $O(1)$ (bounded by the slowest single image load time and concurrent network connection limits). 

🔬 **Measurement**: Can be verified visually by observing faster subsequent image loads (fewer "loading" states) when navigating through pages requiring multiple cached images (like the Library or Albums views), and by monitoring the timeline in Flutter DevTools to confirm parallel network requests.

---
*PR created automatically by Jules for task [15379484133922592402](https://jules.google.com/task/15379484133922592402) started by @p2o51*