### PR TITLE
⚡ Bolt: Use Future.wait for concurrent image preloading

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-05-19 - [Optimize Flutter Provider Selector for High-Frequency Streams]
 **Learning:** When using `Selector` in Flutter with high-frequency streams (like audio playback `progressMs`), passing the raw rapidly changing value into the `builder` causes excessive widget rebuilds.
 **Action:** Calculate the stable derived state (e.g., `currentLineIndex`) *inside* the `selector` callback and return a snapshot containing only the derived state. Update `shouldRebuild` to compare this derived state, ensuring the UI only rebuilds when visually necessary (e.g., when the lyric line changes, not on every millisecond tick).
+
+## 2024-05-19 - Concurrent Preloading of Images
+**Learning:** Sequential preloading of image URLs in a loop (using `await precacheImage()`) creates a network waterfall, significantly delaying UI rendering when multiple images are involved.
+**Action:** When preloading a batch of images (e.g., in a manager like `SpotifyCacheManager`), always map the requests to Futures and execute them concurrently with `Future.wait()`.

--- a/lib/managers/spotify_cache_manager.dart
+++ b/lib/managers/spotify_cache_manager.dart
@@ -19,12 +19,15 @@ class SpotifyCacheManager {
   static const int playlistCacheMaxSize = 30;
 
   // 使用 LRU 缓存限制内存使用
-  final LruCache<String, String> _imageCache =
-      LruCache(maxSize: imageCacheMaxSize);
-  final LruCache<String, Map<String, dynamic>> _albumCache =
-      LruCache(maxSize: albumCacheMaxSize);
-  final LruCache<String, Map<String, dynamic>> _playlistCache =
-      LruCache(maxSize: playlistCacheMaxSize);
+  final LruCache<String, String> _imageCache = LruCache(
+    maxSize: imageCacheMaxSize,
+  );
+  final LruCache<String, Map<String, dynamic>> _albumCache = LruCache(
+    maxSize: albumCacheMaxSize,
+  );
+  final LruCache<String, Map<String, dynamic>> _playlistCache = LruCache(
+    maxSize: playlistCacheMaxSize,
+  );
 
   // ============ 图片缓存 ============
 
@@ -54,12 +57,9 @@ class SpotifyCacheManager {
     List<String> imageUrls,
     BuildContext context,
   ) async {
-    final uncachedUrls =
-        imageUrls.where((url) => !isImageCached(url)).toList();
+    final uncachedUrls = imageUrls.where((url) => !isImageCached(url)).toList();
 
-    for (final url in uncachedUrls) {
-      await preloadImage(url, context);
-    }
+    await Future.wait(uncachedUrls.map((url) => preloadImage(url, context)));
   }
 
   /// 清除图片缓存


### PR DESCRIPTION
**💡 What:** Refactored `preloadImages` in `lib/managers/spotify_cache_manager.dart` to execute the `preloadImage` requests concurrently instead of sequentially.

**🎯 Why:** Iterating over uncached URLs with a `for` loop and `await`ing each preloading call created a network request waterfall. Executing them concurrently removes this artificial sequential delay.

**📊 Impact:** Drastically reduces total image preloading time by launching network requests in parallel rather than blocking on the completion of the prior request.

**🔬 Measurement:** Observe overall faster album/playlist image loading times during bulk initializations or cache warm-ups, especially noticeable when many uncached images are encountered.

---
*PR created automatically by Jules for task [10361689943871641782](https://jules.google.com/task/10361689943871641782) started by @p2o51*